### PR TITLE
URL tray + plan mode + Mac perms strip — 22 commits

### DIFF
--- a/QuipMac/QuipMac.xcodeproj/project.pbxproj
+++ b/QuipMac/QuipMac.xcodeproj/project.pbxproj
@@ -20,11 +20,10 @@
 		2D3A9D787C29669647538F78 /* TerminalStateDetector.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4B67C6602EBEE7D97BCE304 /* TerminalStateDetector.swift */; };
 		3A4AA39F4C89AA307F54001D /* MonitorSelector.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4807DB7DFE825999F9E15D66 /* MonitorSelector.swift */; };
 		3E80AB53764777CE3E79A463 /* MessageProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = EFB206BDF80C59B557B5561A /* MessageProtocol.swift */; };
-		405C2643FFA12E1F1BDC8337 /* QuipMacApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = "TEMP_7DB11D4C-BAC0-478E-9F01-6644C2567E9D" /* QuipMacApp.swift */; };
-		420919AE24CAE973B2AE3E16 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = "TEMP_9CB0A0D3-06E0-4846-A5D0-68DFD17BC7E7" /* Assets.xcassets */; };
 		425DCC822BD1C987A508873B /* DefaultLayouts.json in Resources */ = {isa = PBXBuildFile; fileRef = CD526E4C21F232FACDCD3F3F /* DefaultLayouts.json */; };
 		44D85DED79B8403CA7AE7459 /* WindowInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = ADE18C6DB634684CAA7FE1D5 /* WindowInfo.swift */; };
 		4C1F7E7F9836B4D3EF5D6FD7 /* LayoutPresetTabs.swift in Sources */ = {isa = PBXBuildFile; fileRef = C57A110912607ACED6E89B19 /* LayoutPresetTabs.swift */; };
+		6206170D640DFCB204C0CD84 /* ClaudeModeDetector.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11E45D24608373377E2D46D3 /* ClaudeModeDetector.swift */; };
 		63FE4D9F58CCE850B4F8D7FE /* SettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFDA71A2750027A58181E528 /* SettingsView.swift */; };
 		6A687DBD83641F9456CDB731 /* KeystrokeInjector.swift in Sources */ = {isa = PBXBuildFile; fileRef = A56A336266F29BFDA4CB1C10 /* KeystrokeInjector.swift */; };
 		6AF59F80397868055AA1DA8F /* PINManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 06BBCCD34532C15A5A05B49A /* PINManager.swift */; };
@@ -37,8 +36,10 @@
 		9B4D46C0E2C0623E6F9BE1C6 /* MainWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C947C022B2F6D1CB4FED43F /* MainWindow.swift */; };
 		9E9263F5B804961A1B7225A8 /* KokoroTTS.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6ED3CA65D3DE8E2C7DCF5769 /* KokoroTTS.swift */; };
 		A81002D85A2BC5AA5976AFCF /* WebSocketServer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3EC90466A8AD9BEAE5A07DDC /* WebSocketServer.swift */; };
+		B2C8CF9F384FF76115CCA083 /* QuipMacApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = "TEMP_00EC804A-C3B1-4E30-8C89-539795DCD491" /* QuipMacApp.swift */; };
 		B8F784DAB51BBEBD94DE4D1A /* APNsJWTTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FBBECC11724C6B7430E8A8DA /* APNsJWTTests.swift */; };
 		BB7AD29C435EAFFE6F8DED12 /* MenuBarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 81BB452979FFEEB64D818B68 /* MenuBarView.swift */; };
+		BCBF7ADBCFE67CE05E25BD6F /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = "TEMP_726F6F4B-5A04-4740-864B-DCC652A8E8EB" /* Assets.xcassets */; };
 		BF0FBA9E0D24561D417C885D /* ImageUploadHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B0B9C724A81CC5A243284D8 /* ImageUploadHandler.swift */; };
 		BFAEC96E6C28193C492E7873 /* KeystrokeFocusDelayTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45F9BC10D98A7C867B02D5A1 /* KeystrokeFocusDelayTests.swift */; };
 		C3E6AD2C931293FB771CF8CC /* ImageUploadHandlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9432A677E617A6B09DA7DD0B /* ImageUploadHandlerTests.swift */; };
@@ -48,6 +49,7 @@
 		CDECFE9CA16389D2F1B455D5 /* CloudflareTunnel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2212F34B839B3C63906BAD2C /* CloudflareTunnel.swift */; };
 		D771CA86FD23E660375CC1AC /* WindowListSidebar.swift in Sources */ = {isa = PBXBuildFile; fileRef = FBAFA76040229EEE779AC055 /* WindowListSidebar.swift */; };
 		DB25E0C4E38ECC8B9A42D04D /* PermissionProbeService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E4A88C19C3BFF8C38C0B2E4 /* PermissionProbeService.swift */; };
+		E1671AA42F6C302F2E176941 /* ClaudeModeScannerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7E1DC52BCF5C78516007D8A /* ClaudeModeScannerTests.swift */; };
 		E16F140F49A779C15EAA0862 /* SecretRedactor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7F854257F09ED55190DA9754 /* SecretRedactor.swift */; };
 		EB8C0145B42599AFC038A801 /* WindowManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A1FEC6C97F916BC3E12CC91 /* WindowManager.swift */; };
 		F0476745D4BE09BEA5E6FA79 /* AuditLogger.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FFBB5F208F16F99E170009A /* AuditLogger.swift */; };
@@ -67,6 +69,7 @@
 
 /* Begin PBXFileReference section */
 		06BBCCD34532C15A5A05B49A /* PINManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PINManager.swift; sourceTree = "<group>"; };
+		11E45D24608373377E2D46D3 /* ClaudeModeDetector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClaudeModeDetector.swift; sourceTree = "<group>"; };
 		2212F34B839B3C63906BAD2C /* CloudflareTunnel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CloudflareTunnel.swift; sourceTree = "<group>"; };
 		2B0B9C724A81CC5A243284D8 /* ImageUploadHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageUploadHandler.swift; sourceTree = "<group>"; };
 		2E4A88C19C3BFF8C38C0B2E4 /* PermissionProbeService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PermissionProbeService.swift; sourceTree = "<group>"; };
@@ -97,6 +100,7 @@
 		9432A677E617A6B09DA7DD0B /* ImageUploadHandlerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageUploadHandlerTests.swift; sourceTree = "<group>"; };
 		A2B19559A6253B0E85D5C581 /* Color+Hex.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Color+Hex.swift"; sourceTree = "<group>"; };
 		A56A336266F29BFDA4CB1C10 /* KeystrokeInjector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeystrokeInjector.swift; sourceTree = "<group>"; };
+		A7E1DC52BCF5C78516007D8A /* ClaudeModeScannerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClaudeModeScannerTests.swift; sourceTree = "<group>"; };
 		ADE18C6DB634684CAA7FE1D5 /* WindowInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WindowInfo.swift; sourceTree = "<group>"; };
 		AFDA71A2750027A58181E528 /* SettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsView.swift; sourceTree = "<group>"; };
 		B2BE934418962AAB550CF87F /* NetworkMode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkMode.swift; sourceTree = "<group>"; };
@@ -112,9 +116,9 @@
 		FBAFA76040229EEE779AC055 /* WindowListSidebar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WindowListSidebar.swift; sourceTree = "<group>"; };
 		FBBECC11724C6B7430E8A8DA /* APNsJWTTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APNsJWTTests.swift; sourceTree = "<group>"; };
 		FE4C92DB2B69AF079BEC6369 /* TerminalColorManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalColorManager.swift; sourceTree = "<group>"; };
-		"TEMP_7DB11D4C-BAC0-478E-9F01-6644C2567E9D" /* QuipMacApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuipMacApp.swift; sourceTree = "<group>"; };
-		"TEMP_9CB0A0D3-06E0-4846-A5D0-68DFD17BC7E7" /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
-		"TEMP_BEADA82A-FE7A-49CB-8C17-6846457F0DC8" /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
+		"TEMP_00EC804A-C3B1-4E30-8C89-539795DCD491" /* QuipMacApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuipMacApp.swift; sourceTree = "<group>"; };
+		"TEMP_726F6F4B-5A04-4740-864B-DCC652A8E8EB" /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		"TEMP_AB28D062-C9E9-481F-A813-67FC0E25EB6C" /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXGroup section */
@@ -122,6 +126,7 @@
 			isa = PBXGroup;
 			children = (
 				FBBECC11724C6B7430E8A8DA /* APNsJWTTests.swift */,
+				A7E1DC52BCF5C78516007D8A /* ClaudeModeScannerTests.swift */,
 				9432A677E617A6B09DA7DD0B /* ImageUploadHandlerTests.swift */,
 				4AF071C3CBB7547A6D15F74D /* ITermWindowListParserTests.swift */,
 				6C4E4F97BA0BB789B8E2A1D6 /* PushRegisteredDeviceStoreTests.swift */,
@@ -136,6 +141,7 @@
 				81E08E6062A74F4982F5FA16 /* APNsKeyStore.swift */,
 				3FFBB5F208F16F99E170009A /* AuditLogger.swift */,
 				EBFB66F35E0DB7CFEA44761B /* BonjourAdvertiser.swift */,
+				11E45D24608373377E2D46D3 /* ClaudeModeDetector.swift */,
 				2212F34B839B3C63906BAD2C /* CloudflareTunnel.swift */,
 				6F2F800B05C6E3B1022489FD /* ConnectionLog.swift */,
 				2B0B9C724A81CC5A243284D8 /* ImageUploadHandler.swift */,
@@ -243,12 +249,12 @@
 			path = Resources;
 			sourceTree = "<group>";
 		};
-		"TEMP_855FAF1F-C451-4F98-99D4-779BBD1E0B1F" /* QuipMac */ = {
+		"TEMP_8BCC4C22-05FB-46F0-8B96-5A35D9D12C64" /* QuipMac */ = {
 			isa = PBXGroup;
 			children = (
-				"TEMP_7DB11D4C-BAC0-478E-9F01-6644C2567E9D" /* QuipMacApp.swift */,
-				"TEMP_9CB0A0D3-06E0-4846-A5D0-68DFD17BC7E7" /* Assets.xcassets */,
-				"TEMP_BEADA82A-FE7A-49CB-8C17-6846457F0DC8" /* Info.plist */,
+				"TEMP_00EC804A-C3B1-4E30-8C89-539795DCD491" /* QuipMacApp.swift */,
+				"TEMP_726F6F4B-5A04-4740-864B-DCC652A8E8EB" /* Assets.xcassets */,
+				"TEMP_AB28D062-C9E9-481F-A813-67FC0E25EB6C" /* Info.plist */,
 				F621177D73579FB347509BD2 /* Resources */,
 				D32FA749E86D0C4ECD728F1E /* Models */,
 				D87702261819716197ADF4C3 /* Views */,
@@ -336,7 +342,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				420919AE24CAE973B2AE3E16 /* Assets.xcassets in Resources */,
+				BCBF7ADBCFE67CE05E25BD6F /* Assets.xcassets in Resources */,
 				425DCC822BD1C987A508873B /* DefaultLayouts.json in Resources */,
 				CA061A5EA5E9FFFED7B88CA6 /* kokoro_tts.py in Resources */,
 			);
@@ -374,6 +380,7 @@
 				C68B39F81066E2B42D55AE69 /* APNsKeyStore.swift in Sources */,
 				F0476745D4BE09BEA5E6FA79 /* AuditLogger.swift in Sources */,
 				F0BDBE94C7CB5AD6685E33E5 /* BonjourAdvertiser.swift in Sources */,
+				6206170D640DFCB204C0CD84 /* ClaudeModeDetector.swift in Sources */,
 				CDECFE9CA16389D2F1B455D5 /* CloudflareTunnel.swift in Sources */,
 				864A7798EAC351C8B5E8E39F /* Color+Hex.swift in Sources */,
 				8A417F2510A72EBDC859412C /* ConnectionLog.swift in Sources */,
@@ -392,7 +399,7 @@
 				1BFFDD98C1E1578755E3B874 /* PTTWindowTracker.swift in Sources */,
 				DB25E0C4E38ECC8B9A42D04D /* PermissionProbeService.swift in Sources */,
 				9084D0AD136CA9E40A96DE7E /* PushNotificationService.swift in Sources */,
-				405C2643FFA12E1F1BDC8337 /* QuipMacApp.swift in Sources */,
+				B2C8CF9F384FF76115CCA083 /* QuipMacApp.swift in Sources */,
 				E16F140F49A779C15EAA0862 /* SecretRedactor.swift in Sources */,
 				63FE4D9F58CCE850B4F8D7FE /* SettingsView.swift in Sources */,
 				166D5EA3635FC5603D18D5A6 /* TailscaleService.swift in Sources */,
@@ -411,6 +418,7 @@
 			files = (
 				B8F784DAB51BBEBD94DE4D1A /* APNsJWTTests.swift in Sources */,
 				19BF72AF894F3D230BA2B8A6 /* ArrangeLayoutMappingTests.swift in Sources */,
+				E1671AA42F6C302F2E176941 /* ClaudeModeScannerTests.swift in Sources */,
 				CB4CE20C3C4CB1AA46978892 /* ITermWindowListParserTests.swift in Sources */,
 				C3E6AD2C931293FB771CF8CC /* ImageUploadHandlerTests.swift in Sources */,
 				7893732742065279CC924FCF /* ImageUploadMessageTests.swift in Sources */,

--- a/QuipMac/QuipMac.xcodeproj/project.pbxproj
+++ b/QuipMac/QuipMac.xcodeproj/project.pbxproj
@@ -8,10 +8,12 @@
 
 /* Begin PBXBuildFile section */
 		0553EF1A21F0C774DAA2F0D6 /* LayoutPreview.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5EFE906905D43F124D49A7A /* LayoutPreview.swift */; };
+		06739DDE32002EE5EC49534E /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = "TEMP_4BBAEC1A-7687-4777-923C-205772F8C60A" /* Assets.xcassets */; };
 		10651D74B2A895F33F9D4F2B /* MessageProtocolTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F512A11137B9D4537AB6361B /* MessageProtocolTests.swift */; };
 		107399D353901EBFF5FB310B /* NetworkMode.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2BE934418962AAB550CF87F /* NetworkMode.swift */; };
 		116314BEF65175C6546B7FD6 /* PushRegisteredDeviceStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C4E4F97BA0BB789B8E2A1D6 /* PushRegisteredDeviceStoreTests.swift */; };
 		13D5412FA1D65684388478B6 /* MirrorDesktopFilterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 589E484D563BAA76B0634F61 /* MirrorDesktopFilterTests.swift */; };
+		15E7F693296D17701B7805E9 /* KeystrokeInjectorWriteExpressionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E37933B6AB818F38B0D7418F /* KeystrokeInjectorWriteExpressionTests.swift */; };
 		166D5EA3635FC5603D18D5A6 /* TailscaleService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88BE6CF66C22B39C6DAACAA1 /* TailscaleService.swift */; };
 		19BF72AF894F3D230BA2B8A6 /* ArrangeLayoutMappingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B5A07701D8FE93394003C87 /* ArrangeLayoutMappingTests.swift */; };
 		1A23A388645C53D6E41A1238 /* LayoutPreset.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8726F91288D7DA56A936419F /* LayoutPreset.swift */; };
@@ -36,13 +38,12 @@
 		9B4D46C0E2C0623E6F9BE1C6 /* MainWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C947C022B2F6D1CB4FED43F /* MainWindow.swift */; };
 		9E9263F5B804961A1B7225A8 /* KokoroTTS.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6ED3CA65D3DE8E2C7DCF5769 /* KokoroTTS.swift */; };
 		A81002D85A2BC5AA5976AFCF /* WebSocketServer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3EC90466A8AD9BEAE5A07DDC /* WebSocketServer.swift */; };
-		B2C8CF9F384FF76115CCA083 /* QuipMacApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = "TEMP_00EC804A-C3B1-4E30-8C89-539795DCD491" /* QuipMacApp.swift */; };
 		B8F784DAB51BBEBD94DE4D1A /* APNsJWTTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FBBECC11724C6B7430E8A8DA /* APNsJWTTests.swift */; };
 		BB7AD29C435EAFFE6F8DED12 /* MenuBarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 81BB452979FFEEB64D818B68 /* MenuBarView.swift */; };
-		BCBF7ADBCFE67CE05E25BD6F /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = "TEMP_726F6F4B-5A04-4740-864B-DCC652A8E8EB" /* Assets.xcassets */; };
 		BF0FBA9E0D24561D417C885D /* ImageUploadHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B0B9C724A81CC5A243284D8 /* ImageUploadHandler.swift */; };
 		BFAEC96E6C28193C492E7873 /* KeystrokeFocusDelayTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45F9BC10D98A7C867B02D5A1 /* KeystrokeFocusDelayTests.swift */; };
 		C3E6AD2C931293FB771CF8CC /* ImageUploadHandlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9432A677E617A6B09DA7DD0B /* ImageUploadHandlerTests.swift */; };
+		C3F1591EF9D78E5AA608D455 /* QuipMacApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = "TEMP_B36BAD64-5EBE-4CD5-A9C6-F007E4946F42" /* QuipMacApp.swift */; };
 		C68B39F81066E2B42D55AE69 /* APNsKeyStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 81E08E6062A74F4982F5FA16 /* APNsKeyStore.swift */; };
 		CA061A5EA5E9FFFED7B88CA6 /* kokoro_tts.py in Resources */ = {isa = PBXBuildFile; fileRef = 68BD4937C2DB6DD04A719C32 /* kokoro_tts.py */; };
 		CB4CE20C3C4CB1AA46978892 /* ITermWindowListParserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AF071C3CBB7547A6D15F74D /* ITermWindowListParserTests.swift */; };
@@ -109,6 +110,7 @@
 		B5EFE906905D43F124D49A7A /* LayoutPreview.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LayoutPreview.swift; sourceTree = "<group>"; };
 		C57A110912607ACED6E89B19 /* LayoutPresetTabs.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LayoutPresetTabs.swift; sourceTree = "<group>"; };
 		CD526E4C21F232FACDCD3F3F /* DefaultLayouts.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = DefaultLayouts.json; sourceTree = "<group>"; };
+		E37933B6AB818F38B0D7418F /* KeystrokeInjectorWriteExpressionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeystrokeInjectorWriteExpressionTests.swift; sourceTree = "<group>"; };
 		EBFB66F35E0DB7CFEA44761B /* BonjourAdvertiser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BonjourAdvertiser.swift; sourceTree = "<group>"; };
 		EFB206BDF80C59B557B5561A /* MessageProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageProtocol.swift; sourceTree = "<group>"; };
 		F512A11137B9D4537AB6361B /* MessageProtocolTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageProtocolTests.swift; sourceTree = "<group>"; };
@@ -116,9 +118,9 @@
 		FBAFA76040229EEE779AC055 /* WindowListSidebar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WindowListSidebar.swift; sourceTree = "<group>"; };
 		FBBECC11724C6B7430E8A8DA /* APNsJWTTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APNsJWTTests.swift; sourceTree = "<group>"; };
 		FE4C92DB2B69AF079BEC6369 /* TerminalColorManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalColorManager.swift; sourceTree = "<group>"; };
-		"TEMP_00EC804A-C3B1-4E30-8C89-539795DCD491" /* QuipMacApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuipMacApp.swift; sourceTree = "<group>"; };
-		"TEMP_726F6F4B-5A04-4740-864B-DCC652A8E8EB" /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
-		"TEMP_AB28D062-C9E9-481F-A813-67FC0E25EB6C" /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
+		"TEMP_4BBAEC1A-7687-4777-923C-205772F8C60A" /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		"TEMP_97E72391-9709-4E11-9105-2279ED2433CA" /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
+		"TEMP_B36BAD64-5EBE-4CD5-A9C6-F007E4946F42" /* QuipMacApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuipMacApp.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXGroup section */
@@ -129,6 +131,7 @@
 				A7E1DC52BCF5C78516007D8A /* ClaudeModeScannerTests.swift */,
 				9432A677E617A6B09DA7DD0B /* ImageUploadHandlerTests.swift */,
 				4AF071C3CBB7547A6D15F74D /* ITermWindowListParserTests.swift */,
+				E37933B6AB818F38B0D7418F /* KeystrokeInjectorWriteExpressionTests.swift */,
 				6C4E4F97BA0BB789B8E2A1D6 /* PushRegisteredDeviceStoreTests.swift */,
 			);
 			path = Tests;
@@ -249,12 +252,12 @@
 			path = Resources;
 			sourceTree = "<group>";
 		};
-		"TEMP_8BCC4C22-05FB-46F0-8B96-5A35D9D12C64" /* QuipMac */ = {
+		"TEMP_7472C978-2123-4789-8DEF-1B6137EF96FA" /* QuipMac */ = {
 			isa = PBXGroup;
 			children = (
-				"TEMP_00EC804A-C3B1-4E30-8C89-539795DCD491" /* QuipMacApp.swift */,
-				"TEMP_726F6F4B-5A04-4740-864B-DCC652A8E8EB" /* Assets.xcassets */,
-				"TEMP_AB28D062-C9E9-481F-A813-67FC0E25EB6C" /* Info.plist */,
+				"TEMP_B36BAD64-5EBE-4CD5-A9C6-F007E4946F42" /* QuipMacApp.swift */,
+				"TEMP_4BBAEC1A-7687-4777-923C-205772F8C60A" /* Assets.xcassets */,
+				"TEMP_97E72391-9709-4E11-9105-2279ED2433CA" /* Info.plist */,
 				F621177D73579FB347509BD2 /* Resources */,
 				D32FA749E86D0C4ECD728F1E /* Models */,
 				D87702261819716197ADF4C3 /* Views */,
@@ -342,7 +345,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				BCBF7ADBCFE67CE05E25BD6F /* Assets.xcassets in Resources */,
+				06739DDE32002EE5EC49534E /* Assets.xcassets in Resources */,
 				425DCC822BD1C987A508873B /* DefaultLayouts.json in Resources */,
 				CA061A5EA5E9FFFED7B88CA6 /* kokoro_tts.py in Resources */,
 			);
@@ -399,7 +402,7 @@
 				1BFFDD98C1E1578755E3B874 /* PTTWindowTracker.swift in Sources */,
 				DB25E0C4E38ECC8B9A42D04D /* PermissionProbeService.swift in Sources */,
 				9084D0AD136CA9E40A96DE7E /* PushNotificationService.swift in Sources */,
-				B2C8CF9F384FF76115CCA083 /* QuipMacApp.swift in Sources */,
+				C3F1591EF9D78E5AA608D455 /* QuipMacApp.swift in Sources */,
 				E16F140F49A779C15EAA0862 /* SecretRedactor.swift in Sources */,
 				63FE4D9F58CCE850B4F8D7FE /* SettingsView.swift in Sources */,
 				166D5EA3635FC5603D18D5A6 /* TailscaleService.swift in Sources */,
@@ -423,6 +426,7 @@
 				C3E6AD2C931293FB771CF8CC /* ImageUploadHandlerTests.swift in Sources */,
 				7893732742065279CC924FCF /* ImageUploadMessageTests.swift in Sources */,
 				BFAEC96E6C28193C492E7873 /* KeystrokeFocusDelayTests.swift in Sources */,
+				15E7F693296D17701B7805E9 /* KeystrokeInjectorWriteExpressionTests.swift in Sources */,
 				10651D74B2A895F33F9D4F2B /* MessageProtocolTests.swift in Sources */,
 				13D5412FA1D65684388478B6 /* MirrorDesktopFilterTests.swift in Sources */,
 				2204E721778AD2067D7822DF /* PTTWindowTrackerTests.swift in Sources */,

--- a/QuipMac/QuipMac.xcodeproj/project.pbxproj
+++ b/QuipMac/QuipMac.xcodeproj/project.pbxproj
@@ -23,9 +23,9 @@
 		425DCC822BD1C987A508873B /* DefaultLayouts.json in Resources */ = {isa = PBXBuildFile; fileRef = CD526E4C21F232FACDCD3F3F /* DefaultLayouts.json */; };
 		44D85DED79B8403CA7AE7459 /* WindowInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = ADE18C6DB634684CAA7FE1D5 /* WindowInfo.swift */; };
 		4C1F7E7F9836B4D3EF5D6FD7 /* LayoutPresetTabs.swift in Sources */ = {isa = PBXBuildFile; fileRef = C57A110912607ACED6E89B19 /* LayoutPresetTabs.swift */; };
-		5494DCC5CB13B5D1F33A4FB9 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = "TEMP_A6D4590E-C2E9-4964-BEEB-E5B00859ED63" /* Assets.xcassets */; };
+		54A60BA0DE8342C6E226A4F9 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = "TEMP_37DE9A1D-FC36-427C-AFDE-BB58F2FC5BD4" /* Assets.xcassets */; };
+		5CF7FF11F64AEF0B7778A430 /* QuipMacApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = "TEMP_D53561D4-24B8-455D-821E-E69FBD1E5007" /* QuipMacApp.swift */; };
 		63FE4D9F58CCE850B4F8D7FE /* SettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFDA71A2750027A58181E528 /* SettingsView.swift */; };
-		67E8CAA11B0991EBCBABFA30 /* QuipMacApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = "TEMP_3962EBE2-4830-4C73-9E05-A11E874F78A9" /* QuipMacApp.swift */; };
 		6A687DBD83641F9456CDB731 /* KeystrokeInjector.swift in Sources */ = {isa = PBXBuildFile; fileRef = A56A336266F29BFDA4CB1C10 /* KeystrokeInjector.swift */; };
 		6AF59F80397868055AA1DA8F /* PINManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 06BBCCD34532C15A5A05B49A /* PINManager.swift */; };
 		6FF9FBA8F15F5B3448809A8D /* APNsClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5D9089FAA12F8CDF0710813 /* APNsClient.swift */; };
@@ -44,11 +44,9 @@
 		C3E6AD2C931293FB771CF8CC /* ImageUploadHandlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9432A677E617A6B09DA7DD0B /* ImageUploadHandlerTests.swift */; };
 		C68B39F81066E2B42D55AE69 /* APNsKeyStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 81E08E6062A74F4982F5FA16 /* APNsKeyStore.swift */; };
 		CA061A5EA5E9FFFED7B88CA6 /* kokoro_tts.py in Resources */ = {isa = PBXBuildFile; fileRef = 68BD4937C2DB6DD04A719C32 /* kokoro_tts.py */; };
-		CB3EE27EB6EAFE03A62A1664 /* default.profraw in Resources */ = {isa = PBXBuildFile; fileRef = "TEMP_45BB79D5-27E4-4DFD-B503-35C61EA35CFC" /* default.profraw */; };
 		CB4CE20C3C4CB1AA46978892 /* ITermWindowListParserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AF071C3CBB7547A6D15F74D /* ITermWindowListParserTests.swift */; };
 		CDECFE9CA16389D2F1B455D5 /* CloudflareTunnel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2212F34B839B3C63906BAD2C /* CloudflareTunnel.swift */; };
 		D771CA86FD23E660375CC1AC /* WindowListSidebar.swift in Sources */ = {isa = PBXBuildFile; fileRef = FBAFA76040229EEE779AC055 /* WindowListSidebar.swift */; };
-		DAADB25B04338FA6F2A5DCD0 /* kokoro_tts.cpython-314.pyc in Resources */ = {isa = PBXBuildFile; fileRef = 970F71EC6372BC5075494E87 /* kokoro_tts.cpython-314.pyc */; };
 		E16F140F49A779C15EAA0862 /* SecretRedactor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7F854257F09ED55190DA9754 /* SecretRedactor.swift */; };
 		EB8C0145B42599AFC038A801 /* WindowManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A1FEC6C97F916BC3E12CC91 /* WindowManager.swift */; };
 		F0476745D4BE09BEA5E6FA79 /* AuditLogger.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FFBB5F208F16F99E170009A /* AuditLogger.swift */; };
@@ -95,7 +93,6 @@
 		88BE6CF66C22B39C6DAACAA1 /* TailscaleService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TailscaleService.swift; sourceTree = "<group>"; };
 		8F2FC54EF7BE5384458CC160 /* WindowManagerSessionIdTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WindowManagerSessionIdTests.swift; sourceTree = "<group>"; };
 		9432A677E617A6B09DA7DD0B /* ImageUploadHandlerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageUploadHandlerTests.swift; sourceTree = "<group>"; };
-		970F71EC6372BC5075494E87 /* kokoro_tts.cpython-314.pyc */ = {isa = PBXFileReference; path = "kokoro_tts.cpython-314.pyc"; sourceTree = "<group>"; };
 		A2B19559A6253B0E85D5C581 /* Color+Hex.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Color+Hex.swift"; sourceTree = "<group>"; };
 		A56A336266F29BFDA4CB1C10 /* KeystrokeInjector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeystrokeInjector.swift; sourceTree = "<group>"; };
 		ADE18C6DB634684CAA7FE1D5 /* WindowInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WindowInfo.swift; sourceTree = "<group>"; };
@@ -113,10 +110,9 @@
 		FBAFA76040229EEE779AC055 /* WindowListSidebar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WindowListSidebar.swift; sourceTree = "<group>"; };
 		FBBECC11724C6B7430E8A8DA /* APNsJWTTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APNsJWTTests.swift; sourceTree = "<group>"; };
 		FE4C92DB2B69AF079BEC6369 /* TerminalColorManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalColorManager.swift; sourceTree = "<group>"; };
-		"TEMP_3962EBE2-4830-4C73-9E05-A11E874F78A9" /* QuipMacApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuipMacApp.swift; sourceTree = "<group>"; };
-		"TEMP_45BB79D5-27E4-4DFD-B503-35C61EA35CFC" /* default.profraw */ = {isa = PBXFileReference; path = default.profraw; sourceTree = "<group>"; };
-		"TEMP_A6D4590E-C2E9-4964-BEEB-E5B00859ED63" /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
-		"TEMP_E78D9B90-2361-42FE-AC5F-9DB6C7C6701A" /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
+		"TEMP_37DE9A1D-FC36-427C-AFDE-BB58F2FC5BD4" /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		"TEMP_B48B72AE-2492-4654-A87E-4F7C1CA0FAD6" /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
+		"TEMP_D53561D4-24B8-455D-821E-E69FBD1E5007" /* QuipMacApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuipMacApp.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXGroup section */
@@ -187,14 +183,6 @@
 			path = Models;
 			sourceTree = "<group>";
 		};
-		D686F3BEEC935AE5B55EB2DE /* __pycache__ */ = {
-			isa = PBXGroup;
-			children = (
-				970F71EC6372BC5075494E87 /* kokoro_tts.cpython-314.pyc */,
-			);
-			path = __pycache__;
-			sourceTree = "<group>";
-		};
 		D87702261819716197ADF4C3 /* Views */ = {
 			isa = PBXGroup;
 			children = (
@@ -248,18 +236,16 @@
 			children = (
 				CD526E4C21F232FACDCD3F3F /* DefaultLayouts.json */,
 				68BD4937C2DB6DD04A719C32 /* kokoro_tts.py */,
-				D686F3BEEC935AE5B55EB2DE /* __pycache__ */,
 			);
 			path = Resources;
 			sourceTree = "<group>";
 		};
-		"TEMP_5794F4DB-269D-410D-92D2-654D0FDDADFA" /* QuipMac */ = {
+		"TEMP_31480A43-5780-4FCC-A975-C681520CFBB2" /* QuipMac */ = {
 			isa = PBXGroup;
 			children = (
-				"TEMP_3962EBE2-4830-4C73-9E05-A11E874F78A9" /* QuipMacApp.swift */,
-				"TEMP_E78D9B90-2361-42FE-AC5F-9DB6C7C6701A" /* Info.plist */,
-				"TEMP_A6D4590E-C2E9-4964-BEEB-E5B00859ED63" /* Assets.xcassets */,
-				"TEMP_45BB79D5-27E4-4DFD-B503-35C61EA35CFC" /* default.profraw */,
+				"TEMP_D53561D4-24B8-455D-821E-E69FBD1E5007" /* QuipMacApp.swift */,
+				"TEMP_37DE9A1D-FC36-427C-AFDE-BB58F2FC5BD4" /* Assets.xcassets */,
+				"TEMP_B48B72AE-2492-4654-A87E-4F7C1CA0FAD6" /* Info.plist */,
 				F621177D73579FB347509BD2 /* Resources */,
 				D32FA749E86D0C4ECD728F1E /* Models */,
 				D87702261819716197ADF4C3 /* Views */,
@@ -347,10 +333,8 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				5494DCC5CB13B5D1F33A4FB9 /* Assets.xcassets in Resources */,
+				54A60BA0DE8342C6E226A4F9 /* Assets.xcassets in Resources */,
 				425DCC822BD1C987A508873B /* DefaultLayouts.json in Resources */,
-				CB3EE27EB6EAFE03A62A1664 /* default.profraw in Resources */,
-				DAADB25B04338FA6F2A5DCD0 /* kokoro_tts.cpython-314.pyc in Resources */,
 				CA061A5EA5E9FFFED7B88CA6 /* kokoro_tts.py in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -404,7 +388,7 @@
 				6AF59F80397868055AA1DA8F /* PINManager.swift in Sources */,
 				1BFFDD98C1E1578755E3B874 /* PTTWindowTracker.swift in Sources */,
 				9084D0AD136CA9E40A96DE7E /* PushNotificationService.swift in Sources */,
-				67E8CAA11B0991EBCBABFA30 /* QuipMacApp.swift in Sources */,
+				5CF7FF11F64AEF0B7778A430 /* QuipMacApp.swift in Sources */,
 				E16F140F49A779C15EAA0862 /* SecretRedactor.swift in Sources */,
 				63FE4D9F58CCE850B4F8D7FE /* SettingsView.swift in Sources */,
 				166D5EA3635FC5603D18D5A6 /* TailscaleService.swift in Sources */,

--- a/QuipMac/QuipMac.xcodeproj/project.pbxproj
+++ b/QuipMac/QuipMac.xcodeproj/project.pbxproj
@@ -8,7 +8,6 @@
 
 /* Begin PBXBuildFile section */
 		0553EF1A21F0C774DAA2F0D6 /* LayoutPreview.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5EFE906905D43F124D49A7A /* LayoutPreview.swift */; };
-		06739DDE32002EE5EC49534E /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = "TEMP_4BBAEC1A-7687-4777-923C-205772F8C60A" /* Assets.xcassets */; };
 		10651D74B2A895F33F9D4F2B /* MessageProtocolTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F512A11137B9D4537AB6361B /* MessageProtocolTests.swift */; };
 		107399D353901EBFF5FB310B /* NetworkMode.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2BE934418962AAB550CF87F /* NetworkMode.swift */; };
 		116314BEF65175C6546B7FD6 /* PushRegisteredDeviceStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C4E4F97BA0BB789B8E2A1D6 /* PushRegisteredDeviceStoreTests.swift */; };
@@ -30,6 +29,7 @@
 		6A687DBD83641F9456CDB731 /* KeystrokeInjector.swift in Sources */ = {isa = PBXBuildFile; fileRef = A56A336266F29BFDA4CB1C10 /* KeystrokeInjector.swift */; };
 		6AF59F80397868055AA1DA8F /* PINManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 06BBCCD34532C15A5A05B49A /* PINManager.swift */; };
 		6FF9FBA8F15F5B3448809A8D /* APNsClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5D9089FAA12F8CDF0710813 /* APNsClient.swift */; };
+		776B6808FFB2C42DE93FF535 /* TerminalURLExtractorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 792D57DC8FC3B11646E7AA24 /* TerminalURLExtractorTests.swift */; };
 		7893732742065279CC924FCF /* ImageUploadMessageTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BDEBA5C1FF3ADA484633B4B /* ImageUploadMessageTests.swift */; };
 		82C001C2D1E751B52E9323D6 /* WindowManagerSessionIdTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F2FC54EF7BE5384458CC160 /* WindowManagerSessionIdTests.swift */; };
 		864A7798EAC351C8B5E8E39F /* Color+Hex.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2B19559A6253B0E85D5C581 /* Color+Hex.swift */; };
@@ -38,12 +38,13 @@
 		9B4D46C0E2C0623E6F9BE1C6 /* MainWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C947C022B2F6D1CB4FED43F /* MainWindow.swift */; };
 		9E9263F5B804961A1B7225A8 /* KokoroTTS.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6ED3CA65D3DE8E2C7DCF5769 /* KokoroTTS.swift */; };
 		A81002D85A2BC5AA5976AFCF /* WebSocketServer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3EC90466A8AD9BEAE5A07DDC /* WebSocketServer.swift */; };
+		AF54B4FBF351780F625437CA /* TerminalURLExtractor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73FCC8550866B2D7A72DE1C5 /* TerminalURLExtractor.swift */; };
+		B01F5A5D8EFE27FA3272B597 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = "TEMP_FE786F05-78E4-4B97-8443-013148F4CFC2" /* Assets.xcassets */; };
 		B8F784DAB51BBEBD94DE4D1A /* APNsJWTTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FBBECC11724C6B7430E8A8DA /* APNsJWTTests.swift */; };
 		BB7AD29C435EAFFE6F8DED12 /* MenuBarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 81BB452979FFEEB64D818B68 /* MenuBarView.swift */; };
 		BF0FBA9E0D24561D417C885D /* ImageUploadHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B0B9C724A81CC5A243284D8 /* ImageUploadHandler.swift */; };
 		BFAEC96E6C28193C492E7873 /* KeystrokeFocusDelayTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45F9BC10D98A7C867B02D5A1 /* KeystrokeFocusDelayTests.swift */; };
 		C3E6AD2C931293FB771CF8CC /* ImageUploadHandlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9432A677E617A6B09DA7DD0B /* ImageUploadHandlerTests.swift */; };
-		C3F1591EF9D78E5AA608D455 /* QuipMacApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = "TEMP_B36BAD64-5EBE-4CD5-A9C6-F007E4946F42" /* QuipMacApp.swift */; };
 		C68B39F81066E2B42D55AE69 /* APNsKeyStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 81E08E6062A74F4982F5FA16 /* APNsKeyStore.swift */; };
 		CA061A5EA5E9FFFED7B88CA6 /* kokoro_tts.py in Resources */ = {isa = PBXBuildFile; fileRef = 68BD4937C2DB6DD04A719C32 /* kokoro_tts.py */; };
 		CB4CE20C3C4CB1AA46978892 /* ITermWindowListParserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AF071C3CBB7547A6D15F74D /* ITermWindowListParserTests.swift */; };
@@ -55,6 +56,7 @@
 		EB8C0145B42599AFC038A801 /* WindowManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A1FEC6C97F916BC3E12CC91 /* WindowManager.swift */; };
 		F0476745D4BE09BEA5E6FA79 /* AuditLogger.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FFBB5F208F16F99E170009A /* AuditLogger.swift */; };
 		F0BDBE94C7CB5AD6685E33E5 /* BonjourAdvertiser.swift in Sources */ = {isa = PBXBuildFile; fileRef = EBFB66F35E0DB7CFEA44761B /* BonjourAdvertiser.swift */; };
+		F154694169DAFAA7BBBBAC8C /* QuipMacApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = "TEMP_34437E8B-F476-476A-82F6-102A4BC9A8D7" /* QuipMacApp.swift */; };
 		F6BAA00D69BD1F037B3D22A1 /* TerminalColorManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE4C92DB2B69AF079BEC6369 /* TerminalColorManager.swift */; };
 /* End PBXBuildFile section */
 
@@ -90,6 +92,8 @@
 		6C947C022B2F6D1CB4FED43F /* MainWindow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainWindow.swift; sourceTree = "<group>"; };
 		6ED3CA65D3DE8E2C7DCF5769 /* KokoroTTS.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KokoroTTS.swift; sourceTree = "<group>"; };
 		6F2F800B05C6E3B1022489FD /* ConnectionLog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConnectionLog.swift; sourceTree = "<group>"; };
+		73FCC8550866B2D7A72DE1C5 /* TerminalURLExtractor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalURLExtractor.swift; sourceTree = "<group>"; };
+		792D57DC8FC3B11646E7AA24 /* TerminalURLExtractorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalURLExtractorTests.swift; sourceTree = "<group>"; };
 		7C72FAA7988E0CA53E9ADCCD /* QuipMac.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = QuipMac.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		7F854257F09ED55190DA9754 /* SecretRedactor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SecretRedactor.swift; sourceTree = "<group>"; };
 		81BB452979FFEEB64D818B68 /* MenuBarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuBarView.swift; sourceTree = "<group>"; };
@@ -118,9 +122,9 @@
 		FBAFA76040229EEE779AC055 /* WindowListSidebar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WindowListSidebar.swift; sourceTree = "<group>"; };
 		FBBECC11724C6B7430E8A8DA /* APNsJWTTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APNsJWTTests.swift; sourceTree = "<group>"; };
 		FE4C92DB2B69AF079BEC6369 /* TerminalColorManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalColorManager.swift; sourceTree = "<group>"; };
-		"TEMP_4BBAEC1A-7687-4777-923C-205772F8C60A" /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
-		"TEMP_97E72391-9709-4E11-9105-2279ED2433CA" /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
-		"TEMP_B36BAD64-5EBE-4CD5-A9C6-F007E4946F42" /* QuipMacApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuipMacApp.swift; sourceTree = "<group>"; };
+		"TEMP_34437E8B-F476-476A-82F6-102A4BC9A8D7" /* QuipMacApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuipMacApp.swift; sourceTree = "<group>"; };
+		"TEMP_98A9DC6B-C342-488D-A5AF-D3B963B544B2" /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
+		"TEMP_FE786F05-78E4-4B97-8443-013148F4CFC2" /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXGroup section */
@@ -133,6 +137,7 @@
 				4AF071C3CBB7547A6D15F74D /* ITermWindowListParserTests.swift */,
 				E37933B6AB818F38B0D7418F /* KeystrokeInjectorWriteExpressionTests.swift */,
 				6C4E4F97BA0BB789B8E2A1D6 /* PushRegisteredDeviceStoreTests.swift */,
+				792D57DC8FC3B11646E7AA24 /* TerminalURLExtractorTests.swift */,
 			);
 			path = Tests;
 			sourceTree = "<group>";
@@ -158,6 +163,7 @@
 				88BE6CF66C22B39C6DAACAA1 /* TailscaleService.swift */,
 				FE4C92DB2B69AF079BEC6369 /* TerminalColorManager.swift */,
 				B4B67C6602EBEE7D97BCE304 /* TerminalStateDetector.swift */,
+				73FCC8550866B2D7A72DE1C5 /* TerminalURLExtractor.swift */,
 				3EC90466A8AD9BEAE5A07DDC /* WebSocketServer.swift */,
 				3A1FEC6C97F916BC3E12CC91 /* WindowManager.swift */,
 			);
@@ -252,12 +258,12 @@
 			path = Resources;
 			sourceTree = "<group>";
 		};
-		"TEMP_7472C978-2123-4789-8DEF-1B6137EF96FA" /* QuipMac */ = {
+		"TEMP_527CBE73-B44B-450A-A722-6340A8A840BB" /* QuipMac */ = {
 			isa = PBXGroup;
 			children = (
-				"TEMP_B36BAD64-5EBE-4CD5-A9C6-F007E4946F42" /* QuipMacApp.swift */,
-				"TEMP_4BBAEC1A-7687-4777-923C-205772F8C60A" /* Assets.xcassets */,
-				"TEMP_97E72391-9709-4E11-9105-2279ED2433CA" /* Info.plist */,
+				"TEMP_34437E8B-F476-476A-82F6-102A4BC9A8D7" /* QuipMacApp.swift */,
+				"TEMP_FE786F05-78E4-4B97-8443-013148F4CFC2" /* Assets.xcassets */,
+				"TEMP_98A9DC6B-C342-488D-A5AF-D3B963B544B2" /* Info.plist */,
 				F621177D73579FB347509BD2 /* Resources */,
 				D32FA749E86D0C4ECD728F1E /* Models */,
 				D87702261819716197ADF4C3 /* Views */,
@@ -345,7 +351,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				06739DDE32002EE5EC49534E /* Assets.xcassets in Resources */,
+				B01F5A5D8EFE27FA3272B597 /* Assets.xcassets in Resources */,
 				425DCC822BD1C987A508873B /* DefaultLayouts.json in Resources */,
 				CA061A5EA5E9FFFED7B88CA6 /* kokoro_tts.py in Resources */,
 			);
@@ -402,12 +408,13 @@
 				1BFFDD98C1E1578755E3B874 /* PTTWindowTracker.swift in Sources */,
 				DB25E0C4E38ECC8B9A42D04D /* PermissionProbeService.swift in Sources */,
 				9084D0AD136CA9E40A96DE7E /* PushNotificationService.swift in Sources */,
-				C3F1591EF9D78E5AA608D455 /* QuipMacApp.swift in Sources */,
+				F154694169DAFAA7BBBBAC8C /* QuipMacApp.swift in Sources */,
 				E16F140F49A779C15EAA0862 /* SecretRedactor.swift in Sources */,
 				63FE4D9F58CCE850B4F8D7FE /* SettingsView.swift in Sources */,
 				166D5EA3635FC5603D18D5A6 /* TailscaleService.swift in Sources */,
 				F6BAA00D69BD1F037B3D22A1 /* TerminalColorManager.swift in Sources */,
 				2D3A9D787C29669647538F78 /* TerminalStateDetector.swift in Sources */,
+				AF54B4FBF351780F625437CA /* TerminalURLExtractor.swift in Sources */,
 				A81002D85A2BC5AA5976AFCF /* WebSocketServer.swift in Sources */,
 				44D85DED79B8403CA7AE7459 /* WindowInfo.swift in Sources */,
 				D771CA86FD23E660375CC1AC /* WindowListSidebar.swift in Sources */,
@@ -431,6 +438,7 @@
 				13D5412FA1D65684388478B6 /* MirrorDesktopFilterTests.swift in Sources */,
 				2204E721778AD2067D7822DF /* PTTWindowTrackerTests.swift in Sources */,
 				116314BEF65175C6546B7FD6 /* PushRegisteredDeviceStoreTests.swift in Sources */,
+				776B6808FFB2C42DE93FF535 /* TerminalURLExtractorTests.swift in Sources */,
 				82C001C2D1E751B52E9323D6 /* WindowManagerSessionIdTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/QuipMac/QuipMac.xcodeproj/project.pbxproj
+++ b/QuipMac/QuipMac.xcodeproj/project.pbxproj
@@ -20,11 +20,11 @@
 		2D3A9D787C29669647538F78 /* TerminalStateDetector.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4B67C6602EBEE7D97BCE304 /* TerminalStateDetector.swift */; };
 		3A4AA39F4C89AA307F54001D /* MonitorSelector.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4807DB7DFE825999F9E15D66 /* MonitorSelector.swift */; };
 		3E80AB53764777CE3E79A463 /* MessageProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = EFB206BDF80C59B557B5561A /* MessageProtocol.swift */; };
+		405C2643FFA12E1F1BDC8337 /* QuipMacApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = "TEMP_7DB11D4C-BAC0-478E-9F01-6644C2567E9D" /* QuipMacApp.swift */; };
+		420919AE24CAE973B2AE3E16 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = "TEMP_9CB0A0D3-06E0-4846-A5D0-68DFD17BC7E7" /* Assets.xcassets */; };
 		425DCC822BD1C987A508873B /* DefaultLayouts.json in Resources */ = {isa = PBXBuildFile; fileRef = CD526E4C21F232FACDCD3F3F /* DefaultLayouts.json */; };
 		44D85DED79B8403CA7AE7459 /* WindowInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = ADE18C6DB634684CAA7FE1D5 /* WindowInfo.swift */; };
 		4C1F7E7F9836B4D3EF5D6FD7 /* LayoutPresetTabs.swift in Sources */ = {isa = PBXBuildFile; fileRef = C57A110912607ACED6E89B19 /* LayoutPresetTabs.swift */; };
-		54A60BA0DE8342C6E226A4F9 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = "TEMP_37DE9A1D-FC36-427C-AFDE-BB58F2FC5BD4" /* Assets.xcassets */; };
-		5CF7FF11F64AEF0B7778A430 /* QuipMacApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = "TEMP_D53561D4-24B8-455D-821E-E69FBD1E5007" /* QuipMacApp.swift */; };
 		63FE4D9F58CCE850B4F8D7FE /* SettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFDA71A2750027A58181E528 /* SettingsView.swift */; };
 		6A687DBD83641F9456CDB731 /* KeystrokeInjector.swift in Sources */ = {isa = PBXBuildFile; fileRef = A56A336266F29BFDA4CB1C10 /* KeystrokeInjector.swift */; };
 		6AF59F80397868055AA1DA8F /* PINManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 06BBCCD34532C15A5A05B49A /* PINManager.swift */; };
@@ -47,6 +47,7 @@
 		CB4CE20C3C4CB1AA46978892 /* ITermWindowListParserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AF071C3CBB7547A6D15F74D /* ITermWindowListParserTests.swift */; };
 		CDECFE9CA16389D2F1B455D5 /* CloudflareTunnel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2212F34B839B3C63906BAD2C /* CloudflareTunnel.swift */; };
 		D771CA86FD23E660375CC1AC /* WindowListSidebar.swift in Sources */ = {isa = PBXBuildFile; fileRef = FBAFA76040229EEE779AC055 /* WindowListSidebar.swift */; };
+		DB25E0C4E38ECC8B9A42D04D /* PermissionProbeService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E4A88C19C3BFF8C38C0B2E4 /* PermissionProbeService.swift */; };
 		E16F140F49A779C15EAA0862 /* SecretRedactor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7F854257F09ED55190DA9754 /* SecretRedactor.swift */; };
 		EB8C0145B42599AFC038A801 /* WindowManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A1FEC6C97F916BC3E12CC91 /* WindowManager.swift */; };
 		F0476745D4BE09BEA5E6FA79 /* AuditLogger.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FFBB5F208F16F99E170009A /* AuditLogger.swift */; };
@@ -68,6 +69,7 @@
 		06BBCCD34532C15A5A05B49A /* PINManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PINManager.swift; sourceTree = "<group>"; };
 		2212F34B839B3C63906BAD2C /* CloudflareTunnel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CloudflareTunnel.swift; sourceTree = "<group>"; };
 		2B0B9C724A81CC5A243284D8 /* ImageUploadHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageUploadHandler.swift; sourceTree = "<group>"; };
+		2E4A88C19C3BFF8C38C0B2E4 /* PermissionProbeService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PermissionProbeService.swift; sourceTree = "<group>"; };
 		3A1FEC6C97F916BC3E12CC91 /* WindowManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WindowManager.swift; sourceTree = "<group>"; };
 		3EC90466A8AD9BEAE5A07DDC /* WebSocketServer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebSocketServer.swift; sourceTree = "<group>"; };
 		3FFBB5F208F16F99E170009A /* AuditLogger.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuditLogger.swift; sourceTree = "<group>"; };
@@ -110,9 +112,9 @@
 		FBAFA76040229EEE779AC055 /* WindowListSidebar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WindowListSidebar.swift; sourceTree = "<group>"; };
 		FBBECC11724C6B7430E8A8DA /* APNsJWTTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APNsJWTTests.swift; sourceTree = "<group>"; };
 		FE4C92DB2B69AF079BEC6369 /* TerminalColorManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalColorManager.swift; sourceTree = "<group>"; };
-		"TEMP_37DE9A1D-FC36-427C-AFDE-BB58F2FC5BD4" /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
-		"TEMP_B48B72AE-2492-4654-A87E-4F7C1CA0FAD6" /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
-		"TEMP_D53561D4-24B8-455D-821E-E69FBD1E5007" /* QuipMacApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuipMacApp.swift; sourceTree = "<group>"; };
+		"TEMP_7DB11D4C-BAC0-478E-9F01-6644C2567E9D" /* QuipMacApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuipMacApp.swift; sourceTree = "<group>"; };
+		"TEMP_9CB0A0D3-06E0-4846-A5D0-68DFD17BC7E7" /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		"TEMP_BEADA82A-FE7A-49CB-8C17-6846457F0DC8" /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXGroup section */
@@ -140,6 +142,7 @@
 				A56A336266F29BFDA4CB1C10 /* KeystrokeInjector.swift */,
 				6ED3CA65D3DE8E2C7DCF5769 /* KokoroTTS.swift */,
 				B2BE934418962AAB550CF87F /* NetworkMode.swift */,
+				2E4A88C19C3BFF8C38C0B2E4 /* PermissionProbeService.swift */,
 				06BBCCD34532C15A5A05B49A /* PINManager.swift */,
 				B5BBF33D3BEF237F79631FBD /* PushNotificationService.swift */,
 				7F854257F09ED55190DA9754 /* SecretRedactor.swift */,
@@ -240,12 +243,12 @@
 			path = Resources;
 			sourceTree = "<group>";
 		};
-		"TEMP_31480A43-5780-4FCC-A975-C681520CFBB2" /* QuipMac */ = {
+		"TEMP_855FAF1F-C451-4F98-99D4-779BBD1E0B1F" /* QuipMac */ = {
 			isa = PBXGroup;
 			children = (
-				"TEMP_D53561D4-24B8-455D-821E-E69FBD1E5007" /* QuipMacApp.swift */,
-				"TEMP_37DE9A1D-FC36-427C-AFDE-BB58F2FC5BD4" /* Assets.xcassets */,
-				"TEMP_B48B72AE-2492-4654-A87E-4F7C1CA0FAD6" /* Info.plist */,
+				"TEMP_7DB11D4C-BAC0-478E-9F01-6644C2567E9D" /* QuipMacApp.swift */,
+				"TEMP_9CB0A0D3-06E0-4846-A5D0-68DFD17BC7E7" /* Assets.xcassets */,
+				"TEMP_BEADA82A-FE7A-49CB-8C17-6846457F0DC8" /* Info.plist */,
 				F621177D73579FB347509BD2 /* Resources */,
 				D32FA749E86D0C4ECD728F1E /* Models */,
 				D87702261819716197ADF4C3 /* Views */,
@@ -333,7 +336,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				54A60BA0DE8342C6E226A4F9 /* Assets.xcassets in Resources */,
+				420919AE24CAE973B2AE3E16 /* Assets.xcassets in Resources */,
 				425DCC822BD1C987A508873B /* DefaultLayouts.json in Resources */,
 				CA061A5EA5E9FFFED7B88CA6 /* kokoro_tts.py in Resources */,
 			);
@@ -387,8 +390,9 @@
 				107399D353901EBFF5FB310B /* NetworkMode.swift in Sources */,
 				6AF59F80397868055AA1DA8F /* PINManager.swift in Sources */,
 				1BFFDD98C1E1578755E3B874 /* PTTWindowTracker.swift in Sources */,
+				DB25E0C4E38ECC8B9A42D04D /* PermissionProbeService.swift in Sources */,
 				9084D0AD136CA9E40A96DE7E /* PushNotificationService.swift in Sources */,
-				5CF7FF11F64AEF0B7778A430 /* QuipMacApp.swift in Sources */,
+				405C2643FFA12E1F1BDC8337 /* QuipMacApp.swift in Sources */,
 				E16F140F49A779C15EAA0862 /* SecretRedactor.swift in Sources */,
 				63FE4D9F58CCE850B4F8D7FE /* SettingsView.swift in Sources */,
 				166D5EA3635FC5603D18D5A6 /* TailscaleService.swift in Sources */,

--- a/QuipMac/QuipMacApp.swift
+++ b/QuipMac/QuipMacApp.swift
@@ -273,10 +273,20 @@ struct QuipMacApp: App {
         // phone gets a near-real-time green/red flip when the user grants or
         // revokes a permission. Auth-time broadcast (force=true) covers the
         // first-connection case.
-        Timer.scheduledTimer(withTimeInterval: 5.0, repeats: true) { _ in
+        let permsTimer = Timer.scheduledTimer(withTimeInterval: 5.0, repeats: true) { _ in
             DispatchQueue.main.async {
                 self.broadcastPermissions(force: false)
             }
+        }
+        // .common mode so the timer keeps firing while the user is tracking
+        // a menu/popover (MenuBarExtra). Default mode would pause it.
+        RunLoop.main.add(permsTimer, forMode: .common)
+
+        // Initial broadcast so the snapshot exists before the first phone
+        // client authenticates — keeps the timer's "skip on equality" path
+        // from suppressing the very first send.
+        DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) {
+            self.broadcastPermissions(force: true)
         }
     }
 

--- a/QuipMac/QuipMacApp.swift
+++ b/QuipMac/QuipMacApp.swift
@@ -62,6 +62,10 @@ struct QuipMacApp: App {
     /// which does interrupt any leftover audio from the prior response.
     @State private var ttsSessionIds: [String: String] = [:]
     private let kokoroTTS = KokoroTTS()
+    private let permissionProbe = PermissionProbeService()
+    /// Last broadcast snapshot — keeps the 5s timer from re-sending unchanged
+    /// status every tick. Phone gets fresh status on every client auth anyway.
+    @State private var lastPermissionsSnapshot: MacPermissionsMessage? = nil
 
     var body: some Scene {
         WindowGroup {
@@ -162,6 +166,7 @@ struct QuipMacApp: App {
         webSocketServer.onClientAuthenticated = { [self] in
             DispatchQueue.main.async {
                 self.broadcastLayout()
+                self.broadcastPermissions(force: true)
             }
         }
 
@@ -262,6 +267,44 @@ struct QuipMacApp: App {
                 }
             }
         }
+
+        // Re-probe TCC perms every 5s and only broadcast when the snapshot
+        // actually changes — keeps the wire quiet during steady state but the
+        // phone gets a near-real-time green/red flip when the user grants or
+        // revokes a permission. Auth-time broadcast (force=true) covers the
+        // first-connection case.
+        Timer.scheduledTimer(withTimeInterval: 5.0, repeats: true) { _ in
+            DispatchQueue.main.async {
+                self.broadcastPermissions(force: false)
+            }
+        }
+    }
+
+    /// Probe + broadcast permissions. `force` skips the equality check (used at
+    /// client-auth time so a freshly-connected phone always gets the current state).
+    @MainActor
+    private func broadcastPermissions(force: Bool) {
+        let snapshot = permissionProbe.probe()
+        if !force, snapshot == lastPermissionsSnapshot { return }
+        lastPermissionsSnapshot = snapshot
+        webSocketServer.broadcast(snapshot)
+    }
+
+    /// Open the right `x-apple.systempreferences:` URL for the requested pane.
+    /// Triggered by the phone tapping a red ❌ row in its perm strip.
+    @MainActor
+    private func openSettingsPane(_ pane: MacSettingsPane) {
+        let urlString: String
+        switch pane {
+        case .accessibility:
+            urlString = "x-apple.systempreferences:com.apple.preference.security?Privacy_Accessibility"
+        case .automation:
+            urlString = "x-apple.systempreferences:com.apple.preference.security?Privacy_Automation"
+        case .screenRecording:
+            urlString = "x-apple.systempreferences:com.apple.preference.security?Privacy_ScreenCapture"
+        }
+        guard let url = URL(string: urlString) else { return }
+        NSWorkspace.shared.open(url)
     }
 
     /// Switch between Cloudflare tunnel, Tailscale, and local-only based on
@@ -863,6 +906,12 @@ struct QuipMacApp: App {
                     print("[Quip] preferences_request: no backup for device \(msg.deviceID.prefix(8))")
                 }
                 webSocketServer.broadcast(PreferenceRestoreMessage(preferences: snapshot))
+            }
+
+        case "open_mac_settings_pane":
+            if let msg = MessageCoder.decode(OpenMacSettingsPaneMessage.self, from: data) {
+                print("[Quip] open_mac_settings_pane: \(msg.pane.rawValue)")
+                openSettingsPane(msg.pane)
             }
 
         default:

--- a/QuipMac/QuipMacApp.swift
+++ b/QuipMac/QuipMacApp.swift
@@ -24,6 +24,7 @@ struct QuipMacApp: App {
     @State private var webSocketServer = WebSocketServer()
     @State private var bonjourAdvertiser = BonjourAdvertiser()
     @State private var terminalStateDetector = TerminalStateDetector()
+    @State private var claudeModeDetector = ClaudeModeDetector()
     @State private var terminalColorManager = TerminalColorManager()
     @State private var keystrokeInjector = KeystrokeInjector()
     private let imageUploadHandler = ImageUploadHandler.defaultProduction()
@@ -222,6 +223,12 @@ struct QuipMacApp: App {
         }
 
         terminalStateDetector.startMonitoring()
+        // Mode detector needs to re-broadcast whenever a window flips mode so
+        // iOS clients see plan/autoAccept toggles land within one poll cycle.
+        claudeModeDetector.onModeChange = { [self] _, _, _ in
+            broadcastLayout()
+        }
+        claudeModeDetector.startMonitoring(keystrokeInjector: keystrokeInjector)
         windowManager.refreshDisplays()
         windowManager.refreshWindowList()
         syncTrackedWindows()
@@ -525,7 +532,8 @@ struct QuipMacApp: App {
             window.toWindowState(
                 state: terminalStateDetector.windowStates[window.id]?.rawValue ?? "neutral",
                 screenBounds: screenBounds,
-                isThinking: thinkingWindows.contains(window.id)
+                isThinking: thinkingWindows.contains(window.id),
+                claudeMode: claudeModeDetector.windowModes[window.id]?.rawValue
             )
         }
         let aspect = screenBounds.height > 0 ? Double(screenBounds.width / screenBounds.height) : nil
@@ -1317,6 +1325,21 @@ struct QuipMacApp: App {
             }
         }
 
+        // Mirror the tracked-window set into the mode detector. It polls the
+        // iTerm buffer via AppleScript so the set must include app/windowNumber/
+        // sessionId for each window; otherwise the detector can't target its reads.
+        var modeTracked: [ClaudeModeDetector.TrackedWindow] = []
+        let trackedIds = Set(terminalStateDetector.trackedWindows.keys)
+        for window in windowManager.windows where trackedIds.contains(window.id) {
+            modeTracked.append(.init(
+                windowId: window.id,
+                terminalApp: terminalAppForWindow(window),
+                windowNumber: window.windowNumber,
+                iterm2SessionId: window.iterm2SessionId
+            ))
+        }
+        claudeModeDetector.setTrackedWindows(modeTracked)
+
         // Prune per-window state for windows that no longer exist at all.
         // Without this, dicts like outputHighWaterMarks and sttBaselineContent
         // (each value holds tens of KB of terminal content) accumulate entries
@@ -1330,6 +1353,7 @@ struct QuipMacApp: App {
         ttsSessionIds = ttsSessionIds.filter { allCurrentIds.contains($0.key) }
         pendingInputForWindow = pendingInputForWindow.intersection(allCurrentIds)
         thinkingWindows = thinkingWindows.intersection(allCurrentIds)
+        claudeModeDetector.windowModes = claudeModeDetector.windowModes.filter { allCurrentIds.contains($0.key) }
         if let selected = clientSelectedWindowId, !allCurrentIds.contains(selected) {
             clientSelectedWindowId = nil
         }

--- a/QuipMac/QuipMacApp.swift
+++ b/QuipMac/QuipMacApp.swift
@@ -792,8 +792,13 @@ struct QuipMacApp: App {
                             redacted = "[non-terminal window — screenshot requires Screen Recording permission for Quip]"
                         }
                         let screenshot = keystrokeInjector.captureWindowScreenshot(cgWindowNumber: wn)
+                        // URLs for the iOS tap-to-open tray. Extract from the
+                        // redacted text so SecretRedactor's scrubbing is
+                        // respected — we never ship a URL we also redacted
+                        // from the visible content.
+                        let urls = TerminalURLExtractor.extract(from: redacted)
                         DispatchQueue.main.async {
-                            webSocketServer.broadcast(TerminalContentMessage(windowId: wid, content: redacted, screenshot: screenshot))
+                            webSocketServer.broadcast(TerminalContentMessage(windowId: wid, content: redacted, screenshot: screenshot, urls: urls.isEmpty ? nil : urls))
                         }
                     }
                 }

--- a/QuipMac/QuipMacApp.swift
+++ b/QuipMac/QuipMacApp.swift
@@ -294,6 +294,21 @@ struct QuipMacApp: App {
         // from suppressing the very first send.
         DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) {
             self.broadcastPermissions(force: true)
+            // Screen Recording self-check. Every `QuipMac/` rebuild bumps the
+            // binary's cdhash, and macOS TCC revokes Screen Recording on any
+            // cdhash change even with our stable signing — so a fresh install
+            // frequently lands with screencapture silently denied and the
+            // iPhone falling back to text mode. Without this check, the user
+            // only notices minutes later when they look at the phone. Probe
+            // directly and pop the Screen Recording pane immediately so the
+            // re-grant step is in their face on the next launch after a
+            // rebuild. Skipped when iTerm automation or Accessibility are
+            // the only issues (those tend to survive cdhash changes and
+            // bothering the user with the wrong pane is noisier than the
+            // problem).
+            if !CGPreflightScreenCaptureAccess() {
+                self.openSettingsPane(.screenRecording)
+            }
         }
     }
 

--- a/QuipMac/QuipMacApp.swift
+++ b/QuipMac/QuipMacApp.swift
@@ -821,10 +821,11 @@ struct QuipMacApp: App {
                     // Older iOS clients omit this field — decode to nil,
                     // default to true here so existing phones keep getting
                     // banners until they upgrade.
-                    bannerEnabled: msg.bannerEnabled ?? true
+                    bannerEnabled: msg.bannerEnabled ?? true,
+                    timeZone: msg.timeZone
                 )
                 pushNotificationService.updatePreferences(forDevice: msg.deviceToken, prefs: prefs)
-                print("[Quip] push_preferences updated: paused=\(msg.paused) sound=\(msg.sound) qh=\(msg.quietHoursStart?.description ?? "nil")-\(msg.quietHoursEnd?.description ?? "nil") device=\(msg.deviceToken.prefix(8))")
+                print("[Quip] push_preferences updated: paused=\(msg.paused) sound=\(msg.sound) qh=\(msg.quietHoursStart?.description ?? "nil")-\(msg.quietHoursEnd?.description ?? "nil") tz=\(msg.timeZone ?? "nil") device=\(msg.deviceToken.prefix(8))")
             }
 
         case "attach_iterm_window":

--- a/QuipMac/QuipMacApp.swift
+++ b/QuipMac/QuipMacApp.swift
@@ -1153,6 +1153,19 @@ struct QuipMacApp: App {
             runAfterDelay {
                 keystrokeInjector.sendKeystroke("backspace", to: wid, terminalApp: termApp, cgWindowNumber: wn, iterm2SessionId: window.iterm2SessionId)
             }
+        case "press_shift_tab":
+            // Single Shift+Tab press — manual override / fallback when the
+            // detected mode is unreliable. set_*_mode actions below use
+            // detected mode to compute exact press count.
+            runAfterDelay {
+                keystrokeInjector.sendKeystroke("shift+tab", to: wid, terminalApp: termApp, cgWindowNumber: wn, iterm2SessionId: window.iterm2SessionId)
+            }
+        case "set_plan_mode":
+            cycleClaudeMode(to: .plan, for: window)
+        case "set_auto_accept_mode":
+            cycleClaudeMode(to: .autoAccept, for: window)
+        case "set_normal_mode":
+            cycleClaudeMode(to: .normal, for: window)
         // Ctrl+U — readline "kill to start of line." Wipes the current
         // prompt input in one keystroke instead of holding backspace.
         case "clear_input":
@@ -1190,6 +1203,42 @@ struct QuipMacApp: App {
                 windowManager.markSessionDetached(sessionId: sid)
             }
         default: break
+        }
+    }
+
+    /// Send the right number of Shift+Tab presses to land Claude Code on `target`
+    /// in the cycle (normal → autoAccept → plan → normal). When the current mode
+    /// is unknown (detector hasn't found an indicator yet, or it's been pruned),
+    /// we send ZERO presses and broadcast an `ErrorMessage` to the phone — better
+    /// than blind-pressing and ending up in the wrong mode. The phone-side toast
+    /// tells the user to use the manual `press_shift_tab` action instead.
+    @MainActor
+    private func cycleClaudeMode(to target: ClaudeMode, for window: ManagedWindow) {
+        let current = claudeModeDetector.windowModes[window.id] ?? .normal
+        let knownMode = claudeModeDetector.windowModes[window.id] != nil
+
+        if !knownMode {
+            // No detected indicator yet — refuse to press blind. Tell the user.
+            let err = ErrorMessage(reason: "Can't detect current Claude mode for \(window.name) — press Shift+Tab manually until you see the right indicator.")
+            webSocketServer.broadcast(err)
+            return
+        }
+
+        let presses = ClaudeMode.shiftTabPresses(from: current, to: target)
+        if presses == 0 { return }
+
+        let termApp = terminalAppForWindow(window)
+        let wid = window.id
+        let wn = window.windowNumber
+        let sid = window.iterm2SessionId
+
+        // Stagger the presses by 80ms so Claude Code's TUI has time to redraw
+        // between each Shift+Tab. Without the gap, tightly-coupled presses can
+        // get coalesced and the cycle indicator skips a step.
+        for i in 0..<presses {
+            DispatchQueue.main.asyncAfter(deadline: .now() + Double(i) * 0.08) { [keystrokeInjector] in
+                keystrokeInjector.sendKeystroke("shift+tab", to: wid, terminalApp: termApp, cgWindowNumber: wn, iterm2SessionId: sid)
+            }
         }
     }
 

--- a/QuipMac/Services/ClaudeModeDetector.swift
+++ b/QuipMac/Services/ClaudeModeDetector.swift
@@ -1,0 +1,129 @@
+// ClaudeModeDetector.swift
+// QuipMac — Scrapes Claude Code's current mode (normal / plan / autoAccept) from
+// the terminal buffer of each enabled window. Foundation for shortcut features
+// like real plan-mode cycling (#6) and context-aware prompt-response buttons (#18).
+//
+// Design:
+//   - Reading the terminal buffer costs ~50-200ms per window (AppleScript hop to
+//     iTerm2), so the poll cadence here is deliberately slower (2s) than
+//     TerminalStateDetector's 0.25s. Mode changes are rare — caused only by the
+//     user pressing Shift+Tab — and a 2s detection latency is invisible in practice.
+//   - All buffer reads happen on a background queue; the main-actor state is only
+//     touched for publishing results.
+//   - Only the LAST ~40 lines of the buffer are scanned: Claude Code renders its
+//     mode indicator in the status/footer region, and scanning prose anywhere
+//     earlier would false-positive on transcripts that mention "plan mode on"
+//     in a code block or chat history.
+
+import CoreGraphics
+import Foundation
+import Observation
+
+enum ClaudeModeScanner {
+    /// Scan terminal buffer text for Claude Code's current mode indicator.
+    /// Returns `nil` if no indicator was found (treat as "unknown" / "not a Claude session").
+    /// Only the tail of the buffer is inspected — see `tailLineCount` rationale above.
+    ///
+    /// Cycle order (Shift+Tab): normal → autoAccept → plan → normal. In normal mode
+    /// neither "plan mode on" nor "auto-accept edits on" is visible, so returning .normal
+    /// requires a positive signal that Claude Code is present AND neither string is in the
+    /// tail. We conservatively return nil when neither indicator is found — callers can
+    /// decide to treat nil as "normal mode" if they also have confirmation (e.g. isThinking)
+    /// that Claude is running in that window.
+    static func detect(in bufferText: String, tailLineCount: Int = 40) -> ClaudeMode? {
+        // Take the last N lines — everything above is old prose that could
+        // false-positive on literal mentions of "plan mode on".
+        let lines = bufferText.split(separator: "\n", omittingEmptySubsequences: false)
+        let tail = lines.suffix(tailLineCount).joined(separator: "\n").lowercased()
+
+        // Check plan mode first — if both strings appeared (shouldn't happen),
+        // plan is the more specific state and wins.
+        if tail.contains("plan mode on") {
+            return .plan
+        }
+        if tail.contains("auto-accept edits on") {
+            return .autoAccept
+        }
+        return nil
+    }
+}
+
+@MainActor
+@Observable
+final class ClaudeModeDetector {
+
+    /// Maps window IDs to their last-detected Claude mode. Windows not in the
+    /// dict (or mapped to nil) either haven't been scanned yet or aren't running
+    /// Claude Code at all.
+    var windowModes: [String: ClaudeMode] = [:]
+
+    /// Fires with (windowId, oldMode, newMode) whenever a window's mode changes
+    /// (including first-detection transitions from nil → a value).
+    var onModeChange: ((String, ClaudeMode?, ClaudeMode?) -> Void)?
+
+    /// Cadence at which each tracked window's terminal buffer is scanned.
+    /// 2s is a deliberate compromise between latency and AppleScript cost —
+    /// faster polling would starve the MainActor when many windows are open.
+    var pollingInterval: TimeInterval = 2.0
+
+    private var pollTimer: Timer?
+    private let pollQueue = DispatchQueue(label: "quip.claude-mode-poll", qos: .utility)
+
+    /// Set of (windowId, terminalApp, windowNumber, iterm2SessionId) tuples to poll.
+    /// Populated by the app (QuipMacApp.swift) via setTrackedWindows() each poll cycle.
+    private var tracked: [TrackedWindow] = []
+
+    struct TrackedWindow: Sendable {
+        let windowId: String
+        let terminalApp: TerminalApp
+        let windowNumber: CGWindowID
+        let iterm2SessionId: String?
+    }
+
+    /// Called by the app to refresh the set of windows to scan. Passing enabled
+    /// windows only keeps the poll cost bounded to the windows the user actually cares about.
+    func setTrackedWindows(_ windows: [TrackedWindow]) {
+        tracked = windows
+    }
+
+    func startMonitoring(keystrokeInjector: KeystrokeInjector) {
+        guard pollTimer == nil else { return }
+        pollTimer = Timer.scheduledTimer(withTimeInterval: pollingInterval, repeats: true) { [weak self] _ in
+            self?.pollOnce(keystrokeInjector: keystrokeInjector)
+        }
+        print("[ClaudeModeDetector] Started monitoring (interval: \(pollingInterval)s)")
+    }
+
+    func stopMonitoring() {
+        pollTimer?.invalidate()
+        pollTimer = nil
+        print("[ClaudeModeDetector] Stopped monitoring")
+    }
+
+    private func pollOnce(keystrokeInjector: KeystrokeInjector) {
+        let snapshot = tracked
+        pollQueue.async { [weak self] in
+            guard let self else { return }
+            var results: [(String, ClaudeMode?)] = []
+            for tw in snapshot {
+                let content = keystrokeInjector.readContent(
+                    terminalApp: tw.terminalApp,
+                    cgWindowNumber: tw.windowNumber,
+                    iterm2SessionId: tw.iterm2SessionId
+                ) ?? ""
+                let mode = ClaudeModeScanner.detect(in: content)
+                results.append((tw.windowId, mode))
+            }
+            DispatchQueue.main.async { [weak self] in
+                guard let self else { return }
+                for (windowId, newMode) in results {
+                    let oldMode = self.windowModes[windowId]
+                    if oldMode != newMode {
+                        self.windowModes[windowId] = newMode
+                        self.onModeChange?(windowId, oldMode, newMode)
+                    }
+                }
+            }
+        }
+    }
+}

--- a/QuipMac/Services/KeystrokeInjector.swift
+++ b/QuipMac/Services/KeystrokeInjector.swift
@@ -158,13 +158,12 @@ final class KeystrokeInjector {
     /// raised the correct window before the AppleScript runs.
     @discardableResult
     func sendKeystroke(_ key: String, to windowId: String, terminalApp: TerminalApp, cgWindowNumber: CGWindowID = 0, windowIndex: Int = 1, iterm2SessionId: String? = nil) -> InjectionResult {
-        // iTerm2: use native write-text-with-character-id. Byte-identical to
-        // what typing the key into an iTerm2 session does, reliable because
-        // write text targets a session by object address rather than by
-        // keyboard focus.
+        // iTerm2: use native write-text. Byte-identical to typing the key into an
+        // iTerm2 session, reliable because write text targets a session by object
+        // address rather than by keyboard focus.
         if terminalApp == .iterm2 {
-            guard let charId = iTerm2CharIdFor(key) else {
-                return InjectionResult(success: false, error: "No iTerm2 char id for key: \(key)")
+            guard let writeExpr = Self.iTerm2WriteExpression(for: key) else {
+                return InjectionResult(success: false, error: "No iTerm2 write expression for key: \(key)")
             }
             // Same rule as sendText: refuse to type into a random front window
             // when we don't have a verified session id. A stray Ctrl+C landing
@@ -193,7 +192,7 @@ final class KeystrokeInjector {
                                             -- delete a char and then immediately enter the half-edited
                                             -- input. See sendText's comment above for the same rule on
                                             -- the text path.
-                                            write text (character id \(charId)) newline no
+                                            write text \(writeExpr) newline no
                                         end tell
                                         set quipFound to true
                                         exit repeat
@@ -210,7 +209,7 @@ final class KeystrokeInjector {
                 end if
             end tell
             """
-            return executeAppleScript(script, context: "sendKeystroke \(key) to \(windowId) [iTerm2 write text, charId=\(charId)]")
+            return executeAppleScript(script, context: "sendKeystroke \(key) to \(windowId) [iTerm2 write text, expr=\(writeExpr)]")
         }
 
         // Terminal.app: legacy System Events keystroke path.
@@ -258,6 +257,12 @@ final class KeystrokeInjector {
                 terminalApp: terminalApp, cgWindowNumber: cgWindowNumber, windowIndex: windowIndex
             )
 
+        case "shift+tab":
+            script = keystrokeScript(
+                key: "tab", using: "shift down",
+                terminalApp: terminalApp, cgWindowNumber: cgWindowNumber, windowIndex: windowIndex
+            )
+
         default:
             return InjectionResult(success: false, error: "Unknown key: \(key)")
         }
@@ -265,20 +270,33 @@ final class KeystrokeInjector {
         return executeAppleScript(script, context: "sendKeystroke \(key) to \(windowId) (cgWin=\(cgWindowNumber))")
     }
 
-    /// Map a key descriptor to the ASCII/Unicode codepoint that iTerm2's
-    /// `write text (character id N)` will send into a session. Returns nil for
-    /// unknown keys.
-    private func iTerm2CharIdFor(_ key: String) -> Int? {
+    /// Map a key descriptor to an AppleScript expression suitable as the
+    /// argument to iTerm2's `write text` verb. Single-byte keys come back as
+    /// `(character id N)`. Multi-byte sequences (CSI escape codes like Shift+Tab)
+    /// come back as a concatenation of `character id` plus a literal string,
+    /// which iTerm2 writes verbatim into the session — same effect as a real
+    /// terminal seeing those bytes from the keyboard. Returns nil for unknown keys.
+    ///
+    /// Exposed `internal static` so unit tests can lock the AppleScript shape
+    /// for every key (any drift here breaks every keystroke — high-stakes table).
+    /// Marked `nonisolated` because it's pure / has no instance state, which
+    /// also lets non-MainActor tests call it without an actor hop.
+    nonisolated static func iTerm2WriteExpression(for key: String) -> String? {
         switch key.lowercased() {
-        case "return", "enter":      return 13   // CR
-        case "escape", "esc":        return 27   // ESC
-        case "tab":                  return 9    // HT
-        case "backspace", "delete":  return 127  // DEL
-        case "ctrl+c":               return 3    // ETX / SIGINT
-        case "ctrl+d":               return 4    // EOT / EOF
+        case "return", "enter":      return "(character id 13)"   // CR
+        case "escape", "esc":        return "(character id 27)"   // ESC
+        case "tab":                  return "(character id 9)"    // HT
+        case "backspace", "delete":  return "(character id 127)"  // DEL
+        case "ctrl+c":               return "(character id 3)"    // ETX / SIGINT
+        case "ctrl+d":               return "(character id 4)"    // EOT / EOF
         // NAK — readline "kill backward" (clears prompt to start of line in
         // most TUI input layers, including Claude Code's Ink-based prompt).
-        case "ctrl+u":               return 21
+        case "ctrl+u":               return "(character id 21)"
+        // Shift+Tab is the standard CSI sequence ESC [ Z (`back-tab`). Used by
+        // Claude Code to cycle the editing mode (normal → autoAccept → plan → normal).
+        // iTerm2 writes the concatenated bytes verbatim — the TUI sees them as
+        // the same keypress the user would have pressed on a real keyboard.
+        case "shift+tab":            return #"((character id 27) & "[Z")"#
         default:                     return nil
         }
     }

--- a/QuipMac/Services/KeystrokeInjector.swift
+++ b/QuipMac/Services/KeystrokeInjector.swift
@@ -187,7 +187,13 @@ final class KeystrokeInjector {
                                 repeat with aSession in sessions
                                     if unique id of aSession is "\(escapedId)" then
                                         tell aSession
-                                            write text (character id \(charId))
+                                            -- `newline no` is critical. Without it, iTerm2 appends a
+                                            -- CR after every keystroke — Claude Code's Ink prompt reads
+                                            -- that as "submit," so backspace (and tab/esc/ctrl-*) would
+                                            -- delete a char and then immediately enter the half-edited
+                                            -- input. See sendText's comment above for the same rule on
+                                            -- the text path.
+                                            write text (character id \(charId)) newline no
                                         end tell
                                         set quipFound to true
                                         exit repeat

--- a/QuipMac/Services/PermissionProbeService.swift
+++ b/QuipMac/Services/PermissionProbeService.swift
@@ -1,0 +1,54 @@
+// PermissionProbeService.swift
+// QuipMac — probe the three TCC permissions Quip needs and report status to
+// connected iPhone clients. Lets the phone surface red/green dots without the
+// user having to dig through System Settings to check.
+
+import Foundation
+import ApplicationServices
+import CoreGraphics
+
+@MainActor
+final class PermissionProbeService {
+
+    /// iTerm's bundle ID — what we probe for Apple Events permission. Quip
+    /// primarily drives iTerm; Terminal.app support is incidental, so we don't
+    /// probe both. If a user is iTerm-less, the false-positive is preferable
+    /// to a confusing red dot.
+    static let iTermBundleID = "com.googlecode.iterm2"
+
+    func probe() -> MacPermissionsMessage {
+        MacPermissionsMessage(
+            accessibility: AXIsProcessTrusted(),
+            appleEvents: probeAppleEventsForITerm(),
+            screenRecording: CGPreflightScreenCaptureAccess()
+        )
+    }
+
+    /// Returns false ONLY when the user has explicitly denied Apple Events for
+    /// the target. `procNotFound` (target not running) is treated as granted —
+    /// we can't tell, and the alternative is permanent red until iTerm launches.
+    private func probeAppleEventsForITerm() -> Bool {
+        guard let bundleData = Self.iTermBundleID.data(using: .utf8) else { return true }
+
+        var addressDesc = AEAddressDesc()
+        let createStatus: OSStatus = bundleData.withUnsafeBytes { bytes -> OSStatus in
+            guard let base = bytes.baseAddress else { return OSStatus(Int(errAEWrongDataType)) }
+            return OSStatus(AECreateDesc(typeApplicationBundleID, base, bundleData.count, &addressDesc))
+        }
+        guard createStatus == noErr else { return true }
+        defer { AEDisposeDesc(&addressDesc) }
+
+        let result = AEDeterminePermissionToAutomateTarget(
+            &addressDesc,
+            typeWildCard,
+            typeWildCard,
+            false  // askUserIfNeeded — silent probe
+        )
+        switch result {
+        case noErr: return true
+        case OSStatus(procNotFound): return true
+        case OSStatus(errAEEventNotPermitted): return false
+        default: return true
+        }
+    }
+}

--- a/QuipMac/Services/PushNotificationService.swift
+++ b/QuipMac/Services/PushNotificationService.swift
@@ -41,8 +41,8 @@ struct RegisteredPushDevice: Codable, Equatable, Sendable {
 /// message for a device, we treat it as "allow everything with sound."
 struct DevicePushPreferences: Codable, Equatable, Sendable {
     var paused: Bool = false
-    var quietHoursStart: Int? = nil   // 0-23, local TZ
-    var quietHoursEnd: Int? = nil     // 0-23, local TZ
+    var quietHoursStart: Int? = nil   // 0-23, phone's local TZ
+    var quietHoursEnd: Int? = nil     // 0-23, phone's local TZ
     var sound: Bool = true
     var foregroundBanner: Bool = false
     /// Master banner toggle. False = skip the APNs push entirely so no
@@ -50,15 +50,25 @@ struct DevicePushPreferences: Codable, Equatable, Sendable {
     /// still run because they're driven by WebSocket state changes, not
     /// APNs. Default true for backwards-compat with existing prefs rows.
     var bannerEnabled: Bool = true
+    /// IANA identifier for the phone's TZ at the time prefs were set.
+    /// nil = legacy prefs row or legacy client — fall back to the Mac's
+    /// own `Calendar.current`, which matches the pre-TZ behavior.
+    var timeZone: String? = nil
 
     static let defaults = DevicePushPreferences()
 
     /// True if the current wall-clock hour falls inside the quiet-hours
     /// window. Supports both same-day (start < end, e.g. 13-17) and
     /// overnight (start > end, e.g. 22-7) ranges. Returns false when
-    /// either bound is nil (quiet hours disabled).
-    func isQuietNow(now: Date = Date(), calendar: Calendar = .current) -> Bool {
+    /// either bound is nil (quiet hours disabled). Evaluates the hour in
+    /// the phone's TZ when known, so "10 PM - 7 AM" means the user's 10
+    /// PM even if the Mac is in a different TZ (traveling, remote host).
+    func isQuietNow(now: Date = Date()) -> Bool {
         guard let start = quietHoursStart, let end = quietHoursEnd else { return false }
+        var calendar = Calendar(identifier: .gregorian)
+        if let tzId = timeZone, let parsed = TimeZone(identifier: tzId) {
+            calendar.timeZone = parsed
+        }
         let hour = calendar.component(.hour, from: now)
         if start == end { return false }      // degenerate; treat as disabled
         if start < end { return hour >= start && hour < end }
@@ -260,21 +270,28 @@ final class PushNotificationService {
 
         for device in devicesSnapshot {
             let prefs = prefsSnapshot[device.token] ?? .defaults
+            let tokenPrefix = device.token.prefix(8)
             if prefs.paused {
+                quipPushLog("skip paused — device=\(tokenPrefix) window=\(windowId)")
                 continue
             }
             if !prefs.bannerEnabled {
                 // Banner disabled in iOS Settings → no APNs push. Live
                 // Activity still runs via WebSocket so the island keeps
                 // showing thinking/waiting without the alert tray clutter.
+                quipPushLog("skip banner_disabled — device=\(tokenPrefix) window=\(windowId)")
                 continue
             }
             if prefs.isQuietNow(now: now) {
+                let range = "\(prefs.quietHoursStart?.description ?? "nil")-\(prefs.quietHoursEnd?.description ?? "nil")"
+                quipPushLog("skip quiet_hours — device=\(tokenPrefix) tz=\(prefs.timeZone ?? "mac") range=\(range)")
                 continue
             }
             // Per (windowId, device) debounce
             let debounceKey = "\(windowId)|\(device.token)"
             if let last = lastPushTimes[debounceKey], now.timeIntervalSince(last) < debounceInterval {
+                let elapsed = String(format: "%.1f", now.timeIntervalSince(last))
+                quipPushLog("skip debounce — device=\(tokenPrefix) window=\(windowId) last=\(elapsed)s ago")
                 continue
             }
             lastPushTimes[debounceKey] = now

--- a/QuipMac/Services/TerminalURLExtractor.swift
+++ b/QuipMac/Services/TerminalURLExtractor.swift
@@ -1,0 +1,47 @@
+import Foundation
+
+/// Extracts openable URLs from scraped terminal text to feed the iOS URL tray.
+///
+/// Mirrors the iOS linkifier's scheme filter (QuipiOS/QuipApp.swift ->
+/// `linkifiedTerminalContent`): accept `http(s)://…` and `mailto:…`, reject
+/// bare-TLD false positives that `NSDataDetector` happily matches (README.md,
+/// Quip.app, etc. — `.md` is Moldova's TLD, `.app` is Google's). Keeping the
+/// two rulesets in lockstep is a contract — if iOS ever adds ftp:// or
+/// tel:, update both sides and both test suites in the same commit.
+enum TerminalURLExtractor {
+
+    /// Returns URLs in document order, de-duplicated by absolute string.
+    /// Order matters so the tray matches visual scan order in the terminal.
+    static func extract(from raw: String) -> [String] {
+        guard !raw.isEmpty,
+              let detector = try? NSDataDetector(types: NSTextCheckingResult.CheckingType.link.rawValue)
+        else { return [] }
+
+        let ns = raw as NSString
+        var seen = Set<String>()
+        var ordered: [String] = []
+
+        detector.enumerateMatches(in: raw, options: [], range: NSRange(location: 0, length: ns.length)) { match, _, _ in
+            guard let match, let url = match.url else { return }
+            let matched = ns.substring(with: match.range)
+            let scheme = url.scheme?.lowercased() ?? ""
+            let accepted: Bool
+            if scheme == "mailto" {
+                // NSDataDetector returns bare emails as `mailto:addr@host`;
+                // also accept explicit `mailto:` in the source text.
+                accepted = true
+            } else if scheme == "http" || scheme == "https" {
+                // Require the source substring to carry the scheme literally
+                // so bare `github.com` doesn't get promoted to a link.
+                accepted = matched.hasPrefix("http://") || matched.hasPrefix("https://")
+            } else {
+                accepted = false
+            }
+            guard accepted else { return }
+            let s = url.absoluteString
+            if seen.insert(s).inserted { ordered.append(s) }
+        }
+
+        return ordered
+    }
+}

--- a/QuipMac/Services/WebSocketServer.swift
+++ b/QuipMac/Services/WebSocketServer.swift
@@ -12,6 +12,8 @@ final class WebSocketServer {
 
     var isRunning: Bool = false
     var connectedClientCount: Int = 0
+    /// Number of currently-authenticated direct WebSocket clients. Diagnostic.
+    var authenticatedClientCount: Int { clients.filter(\.isAuthenticated).count }
     var onMessageReceived: ((Data) -> Void)?
     var onClientAuthenticated: (() -> Void)?
     var pinManager: PINManager?

--- a/QuipMac/Services/WindowManager.swift
+++ b/QuipMac/Services/WindowManager.swift
@@ -44,7 +44,7 @@ struct ManagedWindow: Identifiable, Sendable {
 
     /// Convert to shared WindowState for protocol messages.
     /// Frame is normalized to 0-1 relative to the given screen bounds.
-    func toWindowState(state: String = "neutral", screenBounds: CGRect? = nil, isThinking: Bool = false) -> WindowState {
+    func toWindowState(state: String = "neutral", screenBounds: CGRect? = nil, isThinking: Bool = false, claudeMode: String? = nil) -> WindowState {
         let frame: WindowFrame
         if let screen = screenBounds, screen.width > 0, screen.height > 0 {
             frame = WindowFrame(
@@ -70,7 +70,8 @@ struct ManagedWindow: Identifiable, Sendable {
             frame: frame,
             state: state,
             color: assignedColor,
-            isThinking: isThinking
+            isThinking: isThinking,
+            claudeMode: claudeMode
         )
     }
 }

--- a/QuipMac/Tests/ClaudeModeScannerTests.swift
+++ b/QuipMac/Tests/ClaudeModeScannerTests.swift
@@ -1,0 +1,71 @@
+import XCTest
+@testable import Quip
+
+final class ClaudeModeScannerTests: XCTestCase {
+
+    // Happy paths: indicator strings in the tail → mode detected.
+
+    func test_detect_planModeFromFooter() {
+        let buffer = """
+        ... lots of prose above ...
+        some claude output here
+        ⏵⏵ plan mode on  (shift+tab to cycle)
+        """
+        XCTAssertEqual(ClaudeModeScanner.detect(in: buffer), .plan)
+    }
+
+    func test_detect_autoAcceptFromFooter() {
+        let buffer = """
+        >>> running edits...
+        ⏵⏵ auto-accept edits on  (shift+tab to cycle)
+        """
+        XCTAssertEqual(ClaudeModeScanner.detect(in: buffer), .autoAccept)
+    }
+
+    func test_detect_normalMode_returnsNil() {
+        // Normal mode shows no indicator — the scanner returns nil and callers
+        // decide whether to treat nil as normal or unknown.
+        let buffer = """
+        $ claude
+        Welcome to Claude Code.
+        > your prompt here_
+        """
+        XCTAssertNil(ClaudeModeScanner.detect(in: buffer))
+    }
+
+    func test_detect_emptyBuffer_returnsNil() {
+        XCTAssertNil(ClaudeModeScanner.detect(in: ""))
+    }
+
+    // Edge case: an indicator string appearing only in transcript prose far above
+    // the tail window should NOT be caught. This is the whole reason detect()
+    // limits its scan to the last N lines.
+    func test_detect_mentionInOldProse_ignoredByTailWindow() {
+        // The tail window is the last 40 lines by default — pad with filler so
+        // the "plan mode on" mention is pushed above the scan region.
+        let filler = Array(repeating: "filler line", count: 60).joined(separator: "\n")
+        let buffer = """
+        I read a paper that said "plan mode on" changes the behavior.
+        \(filler)
+        $ bare prompt
+        """
+        XCTAssertNil(ClaudeModeScanner.detect(in: buffer))
+    }
+
+    // Guard: both strings present — plan wins, because plan is the more specific
+    // state Claude Code cycles to last in the Shift+Tab order.
+    func test_detect_bothIndicators_planWins() {
+        let buffer = """
+        auto-accept edits on
+        plan mode on
+        """
+        XCTAssertEqual(ClaudeModeScanner.detect(in: buffer), .plan)
+    }
+
+    // Case-insensitive matching — Claude Code renders with lowercase but future
+    // iterations may change capitalization. We lowercase the tail before matching.
+    func test_detect_caseInsensitive() {
+        let buffer = "Plan Mode ON"
+        XCTAssertEqual(ClaudeModeScanner.detect(in: buffer), .plan)
+    }
+}

--- a/QuipMac/Tests/KeystrokeInjectorWriteExpressionTests.swift
+++ b/QuipMac/Tests/KeystrokeInjectorWriteExpressionTests.swift
@@ -1,0 +1,39 @@
+import XCTest
+@testable import Quip
+
+/// Locks the `iTerm2WriteExpression(for:)` table down. Every entry here maps
+/// directly to bytes that get sent into a Claude Code session — silently
+/// changing one of these strings would silently break a keystroke type-wide.
+final class KeystrokeInjectorWriteExpressionTests: XCTestCase {
+
+    func test_singleByteKeys_returnCharacterIdExpressions() {
+        XCTAssertEqual(KeystrokeInjector.iTerm2WriteExpression(for: "return"),    "(character id 13)")
+        XCTAssertEqual(KeystrokeInjector.iTerm2WriteExpression(for: "enter"),     "(character id 13)")
+        XCTAssertEqual(KeystrokeInjector.iTerm2WriteExpression(for: "escape"),    "(character id 27)")
+        XCTAssertEqual(KeystrokeInjector.iTerm2WriteExpression(for: "esc"),       "(character id 27)")
+        XCTAssertEqual(KeystrokeInjector.iTerm2WriteExpression(for: "tab"),       "(character id 9)")
+        XCTAssertEqual(KeystrokeInjector.iTerm2WriteExpression(for: "backspace"), "(character id 127)")
+        XCTAssertEqual(KeystrokeInjector.iTerm2WriteExpression(for: "delete"),    "(character id 127)")
+        XCTAssertEqual(KeystrokeInjector.iTerm2WriteExpression(for: "ctrl+c"),    "(character id 3)")
+        XCTAssertEqual(KeystrokeInjector.iTerm2WriteExpression(for: "ctrl+d"),    "(character id 4)")
+        XCTAssertEqual(KeystrokeInjector.iTerm2WriteExpression(for: "ctrl+u"),    "(character id 21)")
+    }
+
+    /// Shift+Tab is the standard CSI back-tab sequence — ESC followed by `[Z`.
+    /// This is what TUIs (Claude Code, vim, etc.) read as Shift+Tab on a real
+    /// keyboard, and the only safe way to drive Claude Code's mode cycle.
+    func test_shiftTab_isEscapeBracketZ() {
+        XCTAssertEqual(KeystrokeInjector.iTerm2WriteExpression(for: "shift+tab"), #"((character id 27) & "[Z")"#)
+    }
+
+    func test_caseInsensitive() {
+        XCTAssertEqual(KeystrokeInjector.iTerm2WriteExpression(for: "RETURN"),    "(character id 13)")
+        XCTAssertEqual(KeystrokeInjector.iTerm2WriteExpression(for: "Shift+Tab"), #"((character id 27) & "[Z")"#)
+    }
+
+    func test_unknownKey_returnsNil() {
+        XCTAssertNil(KeystrokeInjector.iTerm2WriteExpression(for: "unknown"))
+        XCTAssertNil(KeystrokeInjector.iTerm2WriteExpression(for: ""))
+        XCTAssertNil(KeystrokeInjector.iTerm2WriteExpression(for: "f1"))
+    }
+}

--- a/QuipMac/Tests/TerminalURLExtractorTests.swift
+++ b/QuipMac/Tests/TerminalURLExtractorTests.swift
@@ -1,0 +1,69 @@
+import XCTest
+@testable import Quip
+
+/// Mirror of LinkifiedTerminalContentTests on the iOS side — the two
+/// rulesets must agree, so the same scenarios are pinned here. Adding a
+/// test on one side without the other is a smell: the tray would show
+/// URLs iOS can't tap, or iOS would tap URLs the Mac filtered out.
+final class TerminalURLExtractorTests: XCTestCase {
+
+    func test_https_url_is_extracted() {
+        let urls = TerminalURLExtractor.extract(from: "see https://github.com/anthropic for context")
+        XCTAssertEqual(urls, ["https://github.com/anthropic"])
+    }
+
+    func test_http_url_is_extracted() {
+        let urls = TerminalURLExtractor.extract(from: "fallback http://example.com here")
+        XCTAssertEqual(urls, ["http://example.com"])
+    }
+
+    func test_file_path_is_not_extracted() {
+        let urls = TerminalURLExtractor.extract(from: "edit Sources/Foo.swift line 42")
+        XCTAssertEqual(urls, [])
+    }
+
+    func test_bare_domain_is_not_extracted() {
+        let urls = TerminalURLExtractor.extract(from: "go to github.com to clone")
+        XCTAssertEqual(urls, [])
+    }
+
+    func test_markdown_file_is_not_extracted() {
+        let urls = TerminalURLExtractor.extract(from: "see README.md for setup")
+        XCTAssertEqual(urls, [])
+    }
+
+    func test_app_bundle_is_not_extracted() {
+        let urls = TerminalURLExtractor.extract(from: "rebuild Quip.app and reinstall")
+        XCTAssertEqual(urls, [])
+    }
+
+    func test_bare_email_is_extracted_as_mailto() {
+        let urls = TerminalURLExtractor.extract(from: "contact noreply@anthropic.com for support")
+        XCTAssertEqual(urls, ["mailto:noreply@anthropic.com"])
+    }
+
+    func test_explicit_mailto_is_extracted() {
+        let urls = TerminalURLExtractor.extract(from: "or use mailto:hi@example.com directly")
+        XCTAssertEqual(urls, ["mailto:hi@example.com"])
+    }
+
+    func test_multiple_urls_extracted_in_order() {
+        let urls = TerminalURLExtractor.extract(from: "see https://a.com then https://b.com/path?q=1")
+        XCTAssertEqual(urls, ["https://a.com", "https://b.com/path?q=1"])
+    }
+
+    func test_duplicate_urls_are_deduped() {
+        // Terminal scrollback repeats URLs often (tail -f logs, etc.). The
+        // tray shouldn't render the same pill twice — wastes screen real estate.
+        let urls = TerminalURLExtractor.extract(from: "https://a.com and again https://a.com end")
+        XCTAssertEqual(urls, ["https://a.com"])
+    }
+
+    func test_empty_string() {
+        XCTAssertEqual(TerminalURLExtractor.extract(from: ""), [])
+    }
+
+    func test_no_urls() {
+        XCTAssertEqual(TerminalURLExtractor.extract(from: "just terminal output, nothing linkable"), [])
+    }
+}

--- a/QuipMac/Views/SettingsView.swift
+++ b/QuipMac/Views/SettingsView.swift
@@ -212,8 +212,23 @@ private struct GeneralTab: View {
     @AppStorage("showInDock") private var showInDock = true
     @AppStorage("mirrorDesktop") private var mirrorDesktop = false
 
+    /// Re-probe TCC perms every 3s while this tab is visible so the row
+    /// status flips green within seconds of the user granting in System
+    /// Settings — without forcing the user to bounce back into Quip to
+    /// see it. TimelineView is the cheapest reactive timer in SwiftUI.
+    private let permissionProbe = PermissionProbeService()
+
     var body: some View {
         Form {
+            Section("Permissions") {
+                TimelineView(.periodic(from: .now, by: 3.0)) { _ in
+                    let perms = permissionProbe.probe()
+                    macPermRow(name: "Accessibility", granted: perms.accessibility, pane: .accessibility)
+                    macPermRow(name: "Automation (iTerm)", granted: perms.appleEvents, pane: .automation)
+                    macPermRow(name: "Screen Recording", granted: perms.screenRecording, pane: .screenRecording)
+                }
+            }
+
             Section("Terminal") {
                 Picker("Default Terminal App", selection: $defaultTerminalApp) {
                     ForEach(TerminalApp.allCases) { app in
@@ -242,6 +257,37 @@ private struct GeneralTab: View {
             }
         }
         .formStyle(.grouped)
+    }
+
+    /// One TCC perm row. Granted = green check. Denied = red ✗ + a "Grant"
+    /// button that drops the user straight into the matching System Settings
+    /// pane via an x-apple.systempreferences URL — no nav required.
+    @ViewBuilder
+    private func macPermRow(name: String, granted: Bool, pane: MacSettingsPane) -> some View {
+        HStack(spacing: 8) {
+            Image(systemName: granted ? "checkmark.circle.fill" : "xmark.circle.fill")
+                .foregroundStyle(granted ? Color.green : Color.red)
+            Text(name)
+            Spacer()
+            if !granted {
+                Button("Grant") { openSettingsPane(pane) }
+                    .buttonStyle(.borderless)
+            }
+        }
+    }
+
+    private func openSettingsPane(_ pane: MacSettingsPane) {
+        let urlString: String
+        switch pane {
+        case .accessibility:
+            urlString = "x-apple.systempreferences:com.apple.preference.security?Privacy_Accessibility"
+        case .automation:
+            urlString = "x-apple.systempreferences:com.apple.preference.security?Privacy_Automation"
+        case .screenRecording:
+            urlString = "x-apple.systempreferences:com.apple.preference.security?Privacy_ScreenCapture"
+        }
+        guard let url = URL(string: urlString) else { return }
+        NSWorkspace.shared.open(url)
     }
 }
 

--- a/QuipiOS/QuipApp.swift
+++ b/QuipiOS/QuipApp.swift
@@ -2525,10 +2525,125 @@ struct AttentionPulseDot: View {
     }
 }
 
+/// `UITextView`-backed terminal text view. SwiftUI `Text` with `.link`
+/// AttributedString is documented to be tappable but in practice tap routing
+/// drops to the floor inside our InlineTerminalContent layout (parent
+/// ScrollView gestures + view-modifier cascades both interfere). UITextView
+/// owns its own gesture stack and tap-to-open-url is rock solid.
+///
+/// The view uses `dataDetectorTypes = .link` plus `linkTextAttributes` for
+/// styling, and gets the SAME scheme filter as `linkifiedTerminalContent` via
+/// a delegate `shouldInteractWith url:` hook that rejects taps on non-http(s)
+/// matches (so README.md / Quip.app render as links visually but ignore the
+/// tap; that's a minor cosmetic loss vs. the alternative of building the
+/// attributed string by hand).
+struct LinkableTerminalText: UIViewRepresentable {
+    let content: String
+
+    func makeCoordinator() -> Coordinator { Coordinator() }
+
+    func makeUIView(context: Context) -> UITextView {
+        let tv = UITextView()
+        tv.isEditable = false
+        tv.isSelectable = true
+        tv.isScrollEnabled = true            // owns scrolling
+        tv.backgroundColor = .clear
+        tv.textContainerInset = UIEdgeInsets(top: 6, left: 14, bottom: 6, right: 14)
+        tv.textContainer.lineFragmentPadding = 0
+        tv.dataDetectorTypes = .link
+        tv.linkTextAttributes = [
+            .foregroundColor: UIColor.cyan,
+            .underlineStyle: NSUnderlineStyle.single.rawValue,
+        ]
+        tv.delegate = context.coordinator
+        tv.alwaysBounceVertical = true
+        return tv
+    }
+
+    func updateUIView(_ tv: UITextView, context: Context) {
+        let attr = NSMutableAttributedString(string: content, attributes: [
+            .font: UIFont.monospacedSystemFont(ofSize: 10, weight: .regular),
+            .foregroundColor: UIColor.white.withAlphaComponent(0.85),
+        ])
+        tv.attributedText = attr
+        // Auto-scroll to bottom on new content so latest output is visible
+        // (mirrors the SwiftUI ScrollViewReader.scrollTo("bottom") pattern).
+        let bottom = NSRange(location: max(0, attr.length - 1), length: 1)
+        tv.scrollRangeToVisible(bottom)
+    }
+
+    final class Coordinator: NSObject, UITextViewDelegate {
+        /// iOS 17+ tap handler. The OLD `shouldInteractWith url:in:interaction:`
+        /// delegate method is deprecated; iOS 17 routes taps through this method
+        /// instead and falls through to a no-op if it returns nil. Returning
+        /// the system's default openURL action — wrapped in a fresh UIAction
+        /// to FORCE immediate execution rather than the iOS 17 default of
+        /// showing a Safari-style preview menu first.
+        ///
+        /// Scheme filter: `dataDetectorTypes = .link` matches bare TLDs
+        /// (`README.md` → `http://README.md`, `Quip.app` → `http://Quip.app`).
+        /// We reject those by inspecting the original substring's prefix.
+        @available(iOS 17.0, *)
+        func textView(_ textView: UITextView,
+                      primaryActionFor textItem: UITextItem,
+                      defaultAction: UIAction) -> UIAction? {
+            guard case .link(let url) = textItem.content else { return defaultAction }
+            let scheme = url.scheme?.lowercased() ?? ""
+            let allowed: Bool
+            if scheme == "mailto" {
+                allowed = true
+            } else if scheme == "http" || scheme == "https" {
+                let raw = (textView.attributedText.string as NSString).substring(with: textItem.range)
+                allowed = raw.hasPrefix("http://") || raw.hasPrefix("https://")
+            } else {
+                allowed = false
+            }
+            guard allowed else { return nil }
+            // Return a custom UIAction that calls UIApplication.shared.open
+            // directly. iOS 17's defaultAction sometimes resolves to "show
+            // preview popover" instead of "open immediately"; this guarantees
+            // immediate openURL on tap.
+            return UIAction(title: "Open Link") { _ in
+                UIApplication.shared.open(url, options: [:]) { success in
+                    if !success {
+                        NSLog("[LinkableTerminalText] open(%@) returned false", url.absoluteString)
+                    }
+                }
+            }
+        }
+
+        /// Suppress the iOS 17 link preview menu so tap → open immediately
+        /// without an intermediate "show URL preview" popover.
+        @available(iOS 17.0, *)
+        func textView(_ textView: UITextView,
+                      menuConfigurationFor textItem: UITextItem,
+                      defaultMenu: UIMenu) -> UITextItem.MenuConfiguration? {
+            return nil
+        }
+
+        /// Pre-iOS 17 fallback (unreachable on this app — deployment target is
+        /// iOS 17.0 — but kept defensively in case the project bumps backward).
+        func textView(_ textView: UITextView, shouldInteractWith URL: URL,
+                      in characterRange: NSRange,
+                      interaction: UITextItemInteraction) -> Bool {
+            let scheme = URL.scheme?.lowercased() ?? ""
+            if scheme == "mailto" { return true }
+            if scheme == "http" || scheme == "https" {
+                let raw = (textView.attributedText.string as NSString).substring(with: characterRange)
+                return raw.hasPrefix("http://") || raw.hasPrefix("https://")
+            }
+            return false
+        }
+    }
+}
+
 /// Wrap http(s) URLs in the terminal content with `.link` attributes so SwiftUI's
 /// `Text` renders them as tappable. Only matches with an explicit `http://` or
 /// `https://` prefix are linkified — `NSDataDetector` happily matches bare TLDs,
 /// which would turn `README.md` (`.md` is a real TLD) and `Quip.app` into links.
+///
+/// Kept around for unit-test reuse + as documentation of the scheme-filter rule;
+/// the actual render path now goes through `LinkableTerminalText` (UITextView).
 func linkifiedTerminalContent(_ raw: String) -> AttributedString {
     var attr = AttributedString(raw)
 
@@ -2625,51 +2740,52 @@ struct InlineTerminalContent: View {
             .padding(.vertical, 6)
             .background(Color.white.opacity(0.06))
 
-            ScrollViewReader { proxy in
-                ScrollView {
-                    if let screenshot, let imageData = Data(base64Encoded: screenshot),
-                       let uiImage = UIImage(data: imageData) {
+            // Three render branches:
+            //   - screenshot present → SwiftUI Image inside a ScrollView (zoom/pan)
+            //   - text content present → UITextView (own scroll, tap-to-open URL)
+            //   - empty → "Loading…" placeholder
+            // Branches are kept structurally separate because UITextView wants to
+            // own its scrolling for reliable link tap routing, while the screenshot
+            // path needs SwiftUI ScrollView's scroll-to-bottom hook.
+            if let screenshot, let imageData = Data(base64Encoded: screenshot),
+               let uiImage = UIImage(data: imageData) {
+                ScrollViewReader { proxy in
+                    ScrollView {
                         Image(uiImage: uiImage)
                             .resizable()
                             .scaledToFit()
                             .frame(maxWidth: .infinity)
                             .id("bottom")
-                    } else if !content.isEmpty {
-                        // SwiftUI Text + AttributedString with `.link` SHOULD
-                        // be tappable out of the box, but a `.foregroundStyle`
-                        // modifier on the same Text overrides per-run colors
-                        // AND interferes with link-tap recognition (the link
-                        // attribute and the global foreground style fight for
-                        // priority on the same characters). Fix: bake the
-                        // foreground color INTO the AttributedString itself
-                        // (see `linkifiedTerminalContent`) and drop the
-                        // `.foregroundStyle` modifier here. Then SwiftUI sees
-                        // the link runs as having all the expected styling
-                        // including their own foreground, and routes taps
-                        // through to the system openURL handler.
-                        Text(linkifiedTerminalContent(content))
-                            .font(.system(size: 10, design: .monospaced))
-                            .frame(maxWidth: .infinity, alignment: .leading)
-                            .padding(.horizontal, 14)
-                            .padding(.vertical, 6)
-                            .id("bottom")
-                    } else {
-                        Text("Loading…")
-                            .font(.system(size: 11))
-                            .foregroundStyle(.white.opacity(0.4))
-                            .frame(maxWidth: .infinity)
-                            .padding(16)
-                            .id("bottom")
+                    }
+                    .onChange(of: screenshot) { _, _ in
+                        withAnimation { proxy.scrollTo("bottom", anchor: .bottom) }
                     }
                 }
-                .onChange(of: content) { _, _ in
-                    withAnimation { proxy.scrollTo("bottom", anchor: .bottom) }
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+            } else if !content.isEmpty {
+                VStack(spacing: 0) {
+                    // DIAGNOSTIC — pure SwiftUI Link sitting above the
+                    // UITextView. If this one IS tappable but the cyan URLs
+                    // below aren't, the bug is UITextView-specific.
+                    // If neither tap works, parent SwiftUI is intercepting.
+                    Link(destination: URL(string: "https://github.com")!) {
+                        Text("DEBUG: tap me → github.com")
+                            .font(.system(size: 12, weight: .bold))
+                            .foregroundStyle(.yellow)
+                            .padding(8)
+                            .frame(maxWidth: .infinity)
+                            .background(Color.yellow.opacity(0.2))
+                    }
+                    LinkableTerminalText(content: content)
+                        .frame(maxWidth: .infinity, maxHeight: .infinity)
                 }
-                .onChange(of: screenshot) { _, _ in
-                    withAnimation { proxy.scrollTo("bottom", anchor: .bottom) }
-                }
+            } else {
+                Text("Loading…")
+                    .font(.system(size: 11))
+                    .foregroundStyle(.white.opacity(0.4))
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+                    .padding(16)
             }
-            .frame(maxWidth: .infinity, maxHeight: .infinity)
         }
         .background(colors.overlayContainer)
         .clipShape(RoundedRectangle(cornerRadius: 10))

--- a/QuipiOS/QuipApp.swift
+++ b/QuipiOS/QuipApp.swift
@@ -1632,37 +1632,21 @@ struct MainiOSView: View {
                     let yesNo = enabled.filter { $0 == .yes || $0 == .no }
                     let numbers = enabled.filter { $0 == .one || $0 == .two || $0 == .three }
                     let keystroke = enabled.filter { $0.category == .keystroke }
-                    // `ViewThatFits` tries the spacer-based cluster layout
-                    // first (slash-left / answers-center / keystroke-right,
-                    // aesthetic and aligned with the mic above) and falls
-                    // back to a horizontally-scrollable tight row when too
-                    // many buttons are enabled to fit the phone's width.
-                    // Before this, the cluster row silently overflowed —
-                    // rightmost keystroke buttons got clipped offscreen.
-                    ViewThatFits(in: .horizontal) {
-                        HStack(spacing: 5) {
-                            ForEach(slash) { quickActionButton($0) }
-                            Spacer(minLength: 8)
-                            ForEach(yesNo) { quickActionButton($0) }
-                            // Small fixed gap between Y/N (confirmations)
-                            // and 1/2/3 (numbered choices) — both are
-                            // "answers" but visually distinct sub-groups.
-                            if !yesNo.isEmpty, !numbers.isEmpty {
-                                Spacer().frame(width: 10)
-                            }
-                            ForEach(numbers) { quickActionButton($0) }
-                            Spacer(minLength: 8)
-                            ForEach(keystroke) { quickActionButton($0) }
+                    HStack(spacing: 3) {
+                        ForEach(slash) { quickActionButton($0) }
+                        Spacer(minLength: 6)
+                        ForEach(yesNo) { quickActionButton($0) }
+                        // Small fixed gap between Y/N (confirmations) and
+                        // 1/2/3 (numbered choices) — both are "answers" but
+                        // visually distinct sub-groups.
+                        if !yesNo.isEmpty, !numbers.isEmpty {
+                            Spacer().frame(width: 8)
                         }
-                        .padding(.horizontal, 8)
-
-                        ScrollView(.horizontal, showsIndicators: false) {
-                            HStack(spacing: 4) {
-                                ForEach(enabled) { quickActionButton($0) }
-                            }
-                            .padding(.horizontal, 8)
-                        }
+                        ForEach(numbers) { quickActionButton($0) }
+                        Spacer(minLength: 6)
+                        ForEach(keystroke) { quickActionButton($0) }
                     }
+                    .padding(.horizontal, 6)
                 }
             }
         }
@@ -2416,11 +2400,11 @@ struct MainiOSView: View {
                 }
             }
             .foregroundStyle(.white.opacity(selectedWindowId != nil ? 0.9 : 0.35))
-            .padding(.horizontal, 6)
-            .padding(.vertical, 7)
-            .frame(minWidth: 26)
+            .padding(.horizontal, 4)
+            .padding(.vertical, 5)
+            .frame(minWidth: 20)
             .background(Color.white.opacity(0.15))
-            .clipShape(RoundedRectangle(cornerRadius: 6))
+            .clipShape(RoundedRectangle(cornerRadius: 5))
         }
         .disabled(selectedWindowId == nil)
     }

--- a/QuipiOS/QuipApp.swift
+++ b/QuipiOS/QuipApp.swift
@@ -2705,6 +2705,10 @@ struct InlineTerminalContent: View {
     /// Toggle for the tap-to-open URL tray. Default on. Users who don't want
     /// the extra row between header and screenshot can hide it from Settings.
     @AppStorage("urlTrayEnabled") private var urlTrayEnabled = true
+    /// How many of the most recent URLs to show. Mac sends everything it
+    /// finds in the 200-line scrape window; iOS caps here so a `tail -f`
+    /// log doesn't produce a pill strip that scrolls for days.
+    @AppStorage("urlTrayLimit") private var urlTrayLimit = 10
     /// Zoom level index into `ContentZoomLevel.allCases`. Persisted so the
     /// user's pick survives relaunch, and shared between portrait and
     /// landscape views so cycling in one affects both.
@@ -2750,22 +2754,26 @@ struct InlineTerminalContent: View {
     /// vertical real estate. Each pill: tap → `UIApplication.shared.open`.
     @ViewBuilder
     private var urlTray: some View {
-        if urlTrayEnabled && !urls.isEmpty {
+        // Keep the most recent N URLs — `TerminalURLExtractor` preserves
+        // document order so suffix() == newest. Hide entirely when empty
+        // or when the user has the tray turned off in Settings.
+        let visible = Array(urls.suffix(max(1, urlTrayLimit)))
+        if urlTrayEnabled && !visible.isEmpty {
             ScrollView(.horizontal, showsIndicators: false) {
                 HStack(spacing: 6) {
-                    ForEach(urls, id: \.self) { url in
+                    ForEach(visible, id: \.self) { url in
                         Button {
                             if let u = URL(string: url) {
                                 UIApplication.shared.open(u)
                             }
                         } label: {
                             Text(urlTrayLabel(for: url))
-                                .font(.system(size: 9.5, weight: .medium, design: .monospaced))
+                                .font(.system(size: 8.5, weight: .medium, design: .monospaced))
                                 .lineLimit(1)
                                 .truncationMode(.middle)
                                 .foregroundStyle(Color.cyan)
-                                .padding(.horizontal, 7)
-                                .padding(.vertical, 3)
+                                .padding(.horizontal, 6)
+                                .padding(.vertical, 2)
                                 .background(Color.cyan.opacity(0.15))
                                 .clipShape(Capsule())
                                 .overlay(
@@ -3072,6 +3080,7 @@ struct SettingsSheet: View {
     var macPermissions: MacPermissionsMessage?
     @AppStorage("tintContentBorder") private var tintContentBorder = true
     @AppStorage("urlTrayEnabled") private var urlTrayEnabled = true
+    @AppStorage("urlTrayLimit") private var urlTrayLimit = 10
     @AppStorage("pushPaused") private var pushPaused = false
     @AppStorage("pushBannerEnabled") private var pushBannerEnabled = true
     @AppStorage("pushSound") private var pushSound = true
@@ -3134,6 +3143,10 @@ struct SettingsSheet: View {
                 Section("Appearance") {
                     Toggle("Tint content panel border", isOn: $tintContentBorder)
                     Toggle("URL tray", isOn: $urlTrayEnabled)
+                    if urlTrayEnabled {
+                        Stepper("URL tray limit: \(urlTrayLimit)",
+                                value: $urlTrayLimit, in: 1...50)
+                    }
                 }
 
                 // Notifications — one section. Kill switch on top; the

--- a/QuipiOS/QuipApp.swift
+++ b/QuipiOS/QuipApp.swift
@@ -54,6 +54,10 @@ struct QuipApp: App {
     @State private var textInputValue = ""
     @State private var terminalContentText: String?
     @State private var terminalContentScreenshot: String?
+    /// URLs extracted Mac-side from the scraped text, for the tap-to-open
+    /// tray. nil until first content arrives; empty array from an older Mac
+    /// build (pre-tray) reads as "no URLs" and hides the tray.
+    @State private var terminalContentURLs: [String]?
     @State private var terminalContentWindowId: String?
     @State private var showPINEntry = false
     @State private var pinText = ""
@@ -101,6 +105,7 @@ struct QuipApp: App {
                 isRecording: $isRecording,
                 terminalContentText: $terminalContentText,
                 terminalContentScreenshot: $terminalContentScreenshot,
+                terminalContentURLs: $terminalContentURLs,
                 terminalContentWindowId: $terminalContentWindowId,
                 showPINEntry: $showPINEntry,
                 pinText: $pinText,
@@ -344,11 +349,12 @@ struct QuipApp: App {
             }
         }
 
-        client.onTerminalContent = { windowId, content, screenshot in
+        client.onTerminalContent = { windowId, content, screenshot, urls in
             DispatchQueue.main.async {
                 terminalContentWindowId = windowId
                 terminalContentText = content
                 terminalContentScreenshot = screenshot
+                terminalContentURLs = urls
             }
         }
 
@@ -572,6 +578,7 @@ struct MainiOSView: View {
     @Binding var isRecording: Bool
     @Binding var terminalContentText: String?
     @Binding var terminalContentScreenshot: String?
+    @Binding var terminalContentURLs: [String]?
     @Binding var terminalContentWindowId: String?
     @Binding var showPINEntry: Bool
     @Binding var pinText: String
@@ -845,6 +852,7 @@ struct MainiOSView: View {
             // action buttons looked like they hit the wrong one.
             terminalContentText = nil
             terminalContentScreenshot = nil
+            terminalContentURLs = nil
             terminalContentWindowId = newId
             // Auto-fetch terminal output for the inline view in portrait.
             if isPortrait, let id = newId { onRequestContent(id) }
@@ -1912,6 +1920,7 @@ struct MainiOSView: View {
         InlineTerminalContent(
             content: terminalContentText ?? "",
             screenshot: terminalContentScreenshot,
+            urls: terminalContentURLs ?? [],
             windowName: windows.first(where: { $0.id == selectedWindowId })?.name ?? "",
             windowColor: windows.first(where: { $0.id == selectedWindowId }).map { Color(hex: $0.color) } ?? colors.textSecondary,
             isExpanded: $isTerminalExpanded,
@@ -2682,6 +2691,10 @@ func linkifiedTerminalContent(_ raw: String) -> AttributedString {
 struct InlineTerminalContent: View {
     let content: String
     let screenshot: String?
+    /// URLs extracted Mac-side for the tap-to-open tray. Empty → tray hides.
+    /// Screenshot mode (the typical case) renders URLs as pixels with no tap
+    /// routing, so this tray is how they become interactive.
+    let urls: [String]
     let windowName: String
     let windowColor: Color
     @Binding var isExpanded: Bool
@@ -2694,6 +2707,87 @@ struct InlineTerminalContent: View {
     /// landscape views so cycling in one affects both.
     @AppStorage("contentZoomLevel") private var contentZoomLevel = 1
     private let refreshTimer = Timer.publish(every: 2, on: .main, in: .common).autoconnect()
+
+    /// Which of the three render branches is active. Pinned by
+    /// `InlineTerminalContentBranchTests` so future refactors don't silently
+    /// flip the priority again.
+    enum RenderBranch { case image, text, loading }
+
+    /// Priority: screenshot > text > loading.
+    ///
+    /// Screenshot wins because Claude Code renders its UI in the terminal's
+    /// alternate screen buffer (the bordered input box), and the Mac's
+    /// text scrape (`readContent` in QuipMacApp.swift) only returns the
+    /// main scrollback buffer — text mode would hide the thing users are
+    /// actually looking at. The screenshot captures pixels regardless of
+    /// buffer and preserves ANSI colors.
+    ///
+    /// URLs in the image are pixels and can't be tapped in-situ. That's
+    /// why the header renders a tap-to-open URL tray from the Mac's
+    /// `TerminalURLExtractor` — Claude Code emits plenty of URLs in its
+    /// regular output (commit links, docs references, error URLs) and the
+    /// tray makes them openable without losing the screenshot.
+    static func branch(content: String, screenshot: String?) -> RenderBranch {
+        if let screenshot, let data = Data(base64Encoded: screenshot),
+           UIImage(data: data) != nil {
+            return .image
+        }
+        if !content.isEmpty { return .text }
+        return .loading
+    }
+
+    private var currentBranch: RenderBranch {
+        Self.branch(content: content, screenshot: screenshot)
+    }
+
+    /// Tiny pill in the header showing which render branch is live.
+    /// Horizontal scroll of tap-to-open URL pills. Renders above the
+    /// terminal content, below the window-name header. Hidden entirely when
+    /// `urls` is empty so zero-URL scrapes (the common case) don't burn
+    /// vertical real estate. Each pill: tap → `UIApplication.shared.open`.
+    @ViewBuilder
+    private var urlTray: some View {
+        if !urls.isEmpty {
+            ScrollView(.horizontal, showsIndicators: false) {
+                HStack(spacing: 6) {
+                    ForEach(urls, id: \.self) { url in
+                        Button {
+                            if let u = URL(string: url) {
+                                UIApplication.shared.open(u)
+                            }
+                        } label: {
+                            Text(urlTrayLabel(for: url))
+                                .font(.system(size: 11, weight: .medium, design: .monospaced))
+                                .lineLimit(1)
+                                .truncationMode(.middle)
+                                .foregroundStyle(Color.cyan)
+                                .padding(.horizontal, 8)
+                                .padding(.vertical, 4)
+                                .background(Color.cyan.opacity(0.15))
+                                .clipShape(Capsule())
+                                .overlay(
+                                    Capsule().stroke(Color.cyan.opacity(0.35), lineWidth: 0.5)
+                                )
+                        }
+                        .buttonStyle(.plain)
+                    }
+                }
+                .padding(.horizontal, 10)
+                .padding(.vertical, 5)
+            }
+            .background(Color.white.opacity(0.03))
+        }
+    }
+
+    /// Pill label — drop the scheme prefix for http(s)/mailto because it's
+    /// visual noise that wastes pill width on a phone. The tap handler uses
+    /// the full URL string so functionality is unchanged.
+    private func urlTrayLabel(for url: String) -> String {
+        if url.hasPrefix("https://") { return String(url.dropFirst("https://".count)) }
+        if url.hasPrefix("http://")  { return String(url.dropFirst("http://".count)) }
+        if url.hasPrefix("mailto:")  { return String(url.dropFirst("mailto:".count)) }
+        return url
+    }
 
     var body: some View {
         VStack(spacing: 0) {
@@ -2740,46 +2834,38 @@ struct InlineTerminalContent: View {
             .padding(.vertical, 6)
             .background(Color.white.opacity(0.06))
 
-            // Three render branches:
-            //   - screenshot present → SwiftUI Image inside a ScrollView (zoom/pan)
-            //   - text content present → UITextView (own scroll, tap-to-open URL)
-            //   - empty → "Loading…" placeholder
-            // Branches are kept structurally separate because UITextView wants to
-            // own its scrolling for reliable link tap routing, while the screenshot
-            // path needs SwiftUI ScrollView's scroll-to-bottom hook.
-            if let screenshot, let imageData = Data(base64Encoded: screenshot),
-               let uiImage = UIImage(data: imageData) {
-                ScrollViewReader { proxy in
-                    ScrollView {
-                        Image(uiImage: uiImage)
-                            .resizable()
-                            .scaledToFit()
-                            .frame(maxWidth: .infinity)
-                            .id("bottom")
+            // URL tray above the content area so users can open URLs from
+            // the screenshot (which is pixels and can't be tapped in-situ).
+            urlTray
+
+            // Three render branches, selected by `currentBranch` (pure fn
+            // pinned by InlineTerminalContentBranchTests):
+            //   .image   → SwiftUI Image inside ScrollView (zoom/pan, scroll-to-bottom)
+            //   .text    → UITextView (own scroll, tap-to-open URL) — fallback
+            //              when screenshot capture fails
+            //   .loading → placeholder
+            switch currentBranch {
+            case .image:
+                if let screenshot, let imageData = Data(base64Encoded: screenshot),
+                   let uiImage = UIImage(data: imageData) {
+                    ScrollViewReader { proxy in
+                        ScrollView {
+                            Image(uiImage: uiImage)
+                                .resizable()
+                                .scaledToFit()
+                                .frame(maxWidth: .infinity)
+                                .id("bottom")
+                        }
+                        .onChange(of: screenshot) { _, _ in
+                            withAnimation { proxy.scrollTo("bottom", anchor: .bottom) }
+                        }
                     }
-                    .onChange(of: screenshot) { _, _ in
-                        withAnimation { proxy.scrollTo("bottom", anchor: .bottom) }
-                    }
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
                 }
-                .frame(maxWidth: .infinity, maxHeight: .infinity)
-            } else if !content.isEmpty {
-                VStack(spacing: 0) {
-                    // DIAGNOSTIC — pure SwiftUI Link sitting above the
-                    // UITextView. If this one IS tappable but the cyan URLs
-                    // below aren't, the bug is UITextView-specific.
-                    // If neither tap works, parent SwiftUI is intercepting.
-                    Link(destination: URL(string: "https://github.com")!) {
-                        Text("DEBUG: tap me → github.com")
-                            .font(.system(size: 12, weight: .bold))
-                            .foregroundStyle(.yellow)
-                            .padding(8)
-                            .frame(maxWidth: .infinity)
-                            .background(Color.yellow.opacity(0.2))
-                    }
-                    LinkableTerminalText(content: content)
-                        .frame(maxWidth: .infinity, maxHeight: .infinity)
-                }
-            } else {
+            case .text:
+                LinkableTerminalText(content: content)
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+            case .loading:
                 Text("Loading…")
                     .font(.system(size: 11))
                     .foregroundStyle(.white.opacity(0.4))

--- a/QuipiOS/QuipApp.swift
+++ b/QuipiOS/QuipApp.swift
@@ -170,8 +170,14 @@ struct QuipApp: App {
             }
             .onOpenURL { url in
                 // Deep link from the Live Activity island / lock screen:
-                // quip://window/<windowId> → select that window + open input.
+                //   quip://window/<windowId> — select that window + open input
+                //   quip://perms            — pop the SettingsSheet open (Mac
+                //                             perms section is at the top)
                 guard url.scheme == "quip" else { return }
+                if url.host == "perms" {
+                    NotificationCenter.default.post(name: .quipShowSettings, object: nil)
+                    return
+                }
                 let windowId: String
                 if url.host == "window" {
                     windowId = url.pathComponents.dropFirst().first ?? ""
@@ -349,6 +355,14 @@ struct QuipApp: App {
         client.onMacPermissions = { snapshot in
             DispatchQueue.main.async {
                 macPermissions = snapshot
+                let denied = snapshot.deniedCount
+                if liveActivitiesEnabled {
+                    if denied > 0 {
+                        liveActivity.startOrUpdateMacPerms(deniedCount: denied)
+                    } else {
+                        liveActivity.endMacPerms()
+                    }
+                }
             }
         }
 
@@ -575,6 +589,11 @@ struct MainiOSView: View {
     var onStopRecording: () -> Void
     var onRequestContent: (String) -> Void
     var macPermissions: MacPermissionsMessage?
+    /// Tracks whether we've already auto-popped the SettingsSheet for the
+    /// current connection's first degraded snapshot. Reset on disconnect so a
+    /// reconnect can re-pop if Mac is still degraded — but the 5s update
+    /// stream doesn't keep re-popping after the user dismisses.
+    @State private var hasAutoShownPermsForConnection = false
 
     @AppStorage("lastURL") private var urlText: String = ""
     @AppStorage("recentConnectionsData") private var recentConnectionsData: Data = Data()
@@ -778,6 +797,9 @@ struct MainiOSView: View {
                 if !connected {
                     windows = []
                     selectedWindowId = nil
+                    // Reset auto-pop guard so the next reconnect can re-pop
+                    // the SettingsSheet if Mac is still degraded.
+                    hasAutoShownPermsForConnection = false
                     // If an upload was in flight when the socket dropped,
                     // the ack will never come back. Flip the thumbnail to
                     // an error state immediately so the user can dismiss
@@ -790,6 +812,21 @@ struct MainiOSView: View {
                 }
                 updateOrientation()
             }
+        }
+        .onChange(of: macPermissions) { _, snapshot in
+            // First snapshot of a connection: if Mac is degraded, auto-pop
+            // the SettingsSheet so the user lands on the perm strip without
+            // a manual nav. Only fires once per connection — the 5s update
+            // stream wouldn't get past the guard, and dismissing won't re-pop.
+            guard let s = snapshot, s.deniedCount > 0, !hasAutoShownPermsForConnection else { return }
+            hasAutoShownPermsForConnection = true
+            showSettings = true
+        }
+        .onReceive(NotificationCenter.default.publisher(for: .quipShowSettings)) { _ in
+            // Triggered by the `quip://perms` deep link from the Mac-perms
+            // Live Activity. Goes straight to the SettingsSheet (Mac
+            // Permissions section is at the top).
+            showSettings = true
         }
         .onChange(of: client.isAuthenticated) { _, authenticated in
             withAnimation(.easeInOut(duration: 0.5)) {
@@ -2772,6 +2809,13 @@ enum QuickButton: String, CaseIterable, Identifiable {
 }
 
 // MARK: - Settings Sheet
+
+extension Notification.Name {
+    /// Posted by the `quip://perms` deep-link handler so MainiOSView can pop
+    /// the SettingsSheet. Carries no payload — the sheet always opens to the
+    /// Mac Permissions section (it's at the top).
+    static let quipShowSettings = Notification.Name("quip.showSettings")
+}
 
 struct SettingsSheet: View {
     @Binding var enabledQuickButtonsRaw: String

--- a/QuipiOS/QuipApp.swift
+++ b/QuipiOS/QuipApp.swift
@@ -1938,7 +1938,8 @@ struct MainiOSView: View {
                         client.send(RequestContentMessage(windowId: wid))
                     }
                 }
-            }
+            },
+            onCycleWindow: { direction in cycleWindow(direction: direction) }
         )
     }
 
@@ -2700,6 +2701,10 @@ struct InlineTerminalContent: View {
     @Binding var isExpanded: Bool
     var onRefresh: () -> Void
     var onSendAction: (String) -> Void
+    /// Swipe handler — `direction` is +1 (swipe left = next window) or -1
+    /// (swipe right = previous window), matching `MainiOSView.cycleWindow`.
+    /// Optional for previews / non-swiping callers.
+    var onCycleWindow: ((Int) -> Void)? = nil
     @Environment(\.quipColors) private var colors
     @AppStorage("tintContentBorder") private var tintContentBorder = true
     /// Toggle for the tap-to-open URL tray. Default on. Users who don't want
@@ -2714,6 +2719,20 @@ struct InlineTerminalContent: View {
     /// landscape views so cycling in one affects both.
     @AppStorage("contentZoomLevel") private var contentZoomLevel = 1
     private let refreshTimer = Timer.publish(every: 2, on: .main, in: .common).autoconnect()
+
+    /// Live horizontal offset applied to the content panel while a
+    /// window-cycle swipe is in progress. Dampened to 30% of the finger
+    /// travel + capped at ±80pt so the card feels physical without
+    /// yanking off-screen. Snaps back to 0 on gesture end if the threshold
+    /// isn't hit. Zero when idle.
+    @State private var swipeOffset: CGFloat = 0
+
+    /// 0…1 normalized swipe magnitude, derived from swipeOffset. Used to
+    /// drive the lift-off shadow and the scale-down so the card reads as
+    /// "coming off the top of the deck" rather than just a flat slide.
+    private var swipeProgress: CGFloat {
+        min(1, abs(swipeOffset) / 80)
+    }
 
     /// Which of the three render branches is active. Pinned by
     /// `InlineTerminalContentBranchTests` so future refactors don't silently
@@ -2898,8 +2917,57 @@ struct InlineTerminalContent: View {
                     lineWidth: 1.5
                 )
         )
+        // Deck-of-cards lift: Y-axis 3D flip + slight scale-down + shadow
+        // that grows with swipe magnitude. All three cues together read as
+        // "card being lifted off the top of a stack," not just "view being
+        // dragged sideways." Tuned subtle — max ~9° rotation, 3% shrink,
+        // soft shadow at full swipe.
+        .rotation3DEffect(
+            .degrees(Double(swipeOffset) * 0.22),
+            axis: (x: 0, y: 1, z: 0),
+            perspective: 0.6
+        )
+        .scaleEffect(1 - swipeProgress * 0.03)
+        .shadow(
+            color: .black.opacity(0.45 * swipeProgress),
+            radius: 14 * swipeProgress,
+            x: swipeOffset * 0.2,
+            y: 4 * swipeProgress
+        )
+        .offset(x: swipeOffset)
+        .animation(.interactiveSpring(response: 0.28, dampingFraction: 0.75), value: swipeOffset)
         .onAppear { onRefresh() }
         .onReceive(refreshTimer) { _ in onRefresh() }
+        // Swipe left/right on the panel → cycle windows. Threshold 90pt +
+        // 2:1 horizontal-to-vertical ratio so vertical scroll inside the
+        // image ScrollView + pinch-zoom still work. `simultaneousGesture`
+        // so we don't block the screenshot's own gesture stack.
+        .simultaneousGesture(
+            DragGesture(minimumDistance: 20)
+                .onChanged { value in
+                    let dx = value.translation.width
+                    let dy = value.translation.height
+                    // Only show drag feedback when the motion is clearly
+                    // horizontal — otherwise the panel twitches sideways
+                    // when the user is trying to scroll the screenshot.
+                    guard abs(dx) > abs(dy) * 2 else {
+                        if swipeOffset != 0 { swipeOffset = 0 }
+                        return
+                    }
+                    let damped = dx * 0.35
+                    swipeOffset = max(-80, min(80, damped))
+                }
+                .onEnded { value in
+                    let dx = value.translation.width
+                    let dy = value.translation.height
+                    swipeOffset = 0
+                    guard abs(dx) > 90, abs(dx) > abs(dy) * 2 else { return }
+                    // Left swipe (dx < 0) advances to the NEXT window,
+                    // matching the iOS convention of "content slides left
+                    // to reveal what comes next," like Photos or TabView.
+                    onCycleWindow?(dx < 0 ? 1 : -1)
+                }
+        )
     }
 
     private func keyButton(_ label: String, icon: String?, action: @escaping () -> Void) -> some View {

--- a/QuipiOS/QuipApp.swift
+++ b/QuipiOS/QuipApp.swift
@@ -2548,7 +2548,13 @@ func linkifiedTerminalContent(_ raw: String) -> AttributedString {
         guard let match, let url = match.url,
               let range = Range(match.range, in: attr) else { return }
         let matched = ns.substring(with: match.range)
-        guard matched.hasPrefix("http://") || matched.hasPrefix("https://") else { return }
+        // Allow http(s) explicitly + mailto: for emails (NSDataDetector returns
+        // bare addresses as `mailto:foo@bar.com` URLs natively, so this filter
+        // accepts both `mailto:hi@example.com` substring matches and bare
+        // `noreply@anthropic.com` matches surfaced by the detector).
+        guard matched.hasPrefix("http://") || matched.hasPrefix("https://")
+              || matched.hasPrefix("mailto:") || url.scheme?.lowercased() == "mailto"
+        else { return }
         attr[range].link = url
         attr[range].underlineStyle = .single
         // Brighter foreground for link runs so they stand out from the .85

--- a/QuipiOS/QuipApp.swift
+++ b/QuipiOS/QuipApp.swift
@@ -2531,6 +2531,15 @@ struct AttentionPulseDot: View {
 /// which would turn `README.md` (`.md` is a real TLD) and `Quip.app` into links.
 func linkifiedTerminalContent(_ raw: String) -> AttributedString {
     var attr = AttributedString(raw)
+
+    // Bake the default white foreground into the attributed string itself so
+    // the call site doesn't need a `.foregroundStyle` modifier on the Text.
+    // The modifier interferes with link-tap recognition by making SwiftUI
+    // recompute foreground per-character at render time and stomping on the
+    // link attribute's tap-routing. Setting it on the attributed string
+    // leaves the per-run link runs intact and tappable.
+    attr.foregroundColor = .white.opacity(0.85)
+
     guard let detector = try? NSDataDetector(types: NSTextCheckingResult.CheckingType.link.rawValue) else {
         return attr
     }
@@ -2542,6 +2551,9 @@ func linkifiedTerminalContent(_ raw: String) -> AttributedString {
         guard matched.hasPrefix("http://") || matched.hasPrefix("https://") else { return }
         attr[range].link = url
         attr[range].underlineStyle = .single
+        // Brighter foreground for link runs so they stand out from the .85
+        // white body text — visually distinguishes "this is tappable".
+        attr[range].foregroundColor = .cyan
     }
     return attr
 }
@@ -2617,13 +2629,23 @@ struct InlineTerminalContent: View {
                             .frame(maxWidth: .infinity)
                             .id("bottom")
                     } else if !content.isEmpty {
+                        // SwiftUI Text + AttributedString with `.link` SHOULD
+                        // be tappable out of the box, but a `.foregroundStyle`
+                        // modifier on the same Text overrides per-run colors
+                        // AND interferes with link-tap recognition (the link
+                        // attribute and the global foreground style fight for
+                        // priority on the same characters). Fix: bake the
+                        // foreground color INTO the AttributedString itself
+                        // (see `linkifiedTerminalContent`) and drop the
+                        // `.foregroundStyle` modifier here. Then SwiftUI sees
+                        // the link runs as having all the expected styling
+                        // including their own foreground, and routes taps
+                        // through to the system openURL handler.
                         Text(linkifiedTerminalContent(content))
                             .font(.system(size: 10, design: .monospaced))
-                            .foregroundStyle(.white.opacity(0.85))
                             .frame(maxWidth: .infinity, alignment: .leading)
                             .padding(.horizontal, 14)
                             .padding(.vertical, 6)
-                            .textSelection(.enabled)
                             .id("bottom")
                     } else {
                         Text("Loading…")

--- a/QuipiOS/QuipApp.swift
+++ b/QuipiOS/QuipApp.swift
@@ -64,6 +64,9 @@ struct QuipApp: App {
     /// decoded in QuipApp's `onITermWindowList` callback. Passed down as
     /// a Binding so the sheet can clear it before re-scanning.
     @State private var iTermScanResults: [ITermWindowInfo]? = nil
+    /// Most recent Mac TCC permission snapshot. nil = Mac hasn't sent one yet
+    /// (older Mac build, or just connected and waiting for the first probe).
+    @State private var macPermissions: MacPermissionsMessage? = nil
     @State private var errorToast: String?
     @AppStorage("ttsEnabled") private var ttsEnabled = false
     /// Master toggle for the Dynamic Island / Lock Screen Live Activity.
@@ -115,7 +118,8 @@ struct QuipApp: App {
                 onStopRecording: { DispatchQueue.main.async { stopRecording() } },
                 onRequestContent: { windowId in
                     client.send(RequestContentMessage(windowId: windowId))
-                }
+                },
+                macPermissions: macPermissions
             )
             .environmentObject(pendingImage)
             .onAppear {
@@ -342,6 +346,12 @@ struct QuipApp: App {
             }
         }
 
+        client.onMacPermissions = { snapshot in
+            DispatchQueue.main.async {
+                macPermissions = snapshot
+            }
+        }
+
         client.onOutputDelta = { windowId, windowName, text, isFinal in
             DispatchQueue.main.async {
                 guard ttsEnabled else { return }
@@ -564,6 +574,7 @@ struct MainiOSView: View {
     var onStartRecording: () -> Void
     var onStopRecording: () -> Void
     var onRequestContent: (String) -> Void
+    var macPermissions: MacPermissionsMessage?
 
     @AppStorage("lastURL") private var urlText: String = ""
     @AppStorage("recentConnectionsData") private var recentConnectionsData: Data = Data()
@@ -809,7 +820,12 @@ struct MainiOSView: View {
             }
         }
         .sheet(isPresented: $showSettings) {
-            SettingsSheet(enabledQuickButtonsRaw: $enabledQuickButtonsRaw, client: client, pushRegistration: pushRegistration)
+            SettingsSheet(
+                enabledQuickButtonsRaw: $enabledQuickButtonsRaw,
+                client: client,
+                pushRegistration: pushRegistration,
+                macPermissions: macPermissions
+            )
         }
         // Image-attach sheets — hoisted to the body so both portrait and
         // landscape views can trigger them via the shared @State bindings.
@@ -1265,10 +1281,22 @@ struct MainiOSView: View {
             Button {
                 showSettings = true
             } label: {
-                Image(systemName: "gearshape")
-                    .font(.system(size: 12))
-                    .foregroundStyle(colors.textTertiary)
-                    .frame(width: 20, height: 20)
+                ZStack(alignment: .topTrailing) {
+                    Image(systemName: "gearshape")
+                        .font(.system(size: 12))
+                        .foregroundStyle(colors.textTertiary)
+                        .frame(width: 20, height: 20)
+                    // Red dot when any Mac TCC perm is denied so the user
+                    // notices something needs attention without having to
+                    // open the sheet to find out.
+                    if let perms = macPermissions,
+                       !(perms.accessibility && perms.appleEvents && perms.screenRecording) {
+                        Circle()
+                            .fill(Color.red)
+                            .frame(width: 6, height: 6)
+                            .offset(x: -2, y: 2)
+                    }
+                }
             }
             Button {
                 client.disconnect()
@@ -2749,6 +2777,7 @@ struct SettingsSheet: View {
     @Binding var enabledQuickButtonsRaw: String
     var client: WebSocketClient
     var pushRegistration: PushRegistrationService
+    var macPermissions: MacPermissionsMessage?
     @AppStorage("tintContentBorder") private var tintContentBorder = true
     @AppStorage("pushPaused") private var pushPaused = false
     @AppStorage("pushBannerEnabled") private var pushBannerEnabled = true
@@ -2766,6 +2795,32 @@ struct SettingsSheet: View {
     var body: some View {
         NavigationStack {
             List {
+                // Mac Status — TCC permissions Quip needs on the Mac side.
+                // Tap a red row to pop the right System Settings pane open
+                // remotely so the user doesn't have to dig for it.
+                if let perms = macPermissions {
+                    Section {
+                        macPermRow(name: "Accessibility",
+                                   icon: "accessibility",
+                                   granted: perms.accessibility,
+                                   pane: .accessibility)
+                        macPermRow(name: "Automation (iTerm)",
+                                   icon: "terminal",
+                                   granted: perms.appleEvents,
+                                   pane: .automation)
+                        macPermRow(name: "Screen Recording",
+                                   icon: "rectangle.dashed",
+                                   granted: perms.screenRecording,
+                                   pane: .screenRecording)
+                    } header: {
+                        Text("Mac Permissions")
+                    } footer: {
+                        if !(perms.accessibility && perms.appleEvents && perms.screenRecording) {
+                            Text("Tap a red row — Mac will pop the right System Settings pane open.")
+                        }
+                    }
+                }
+
                 // Appearance — single-row section; footer goes away once the
                 // feature's self-explanatory so the page stops feeling padded.
                 Section("Appearance") {
@@ -2834,6 +2889,37 @@ struct SettingsSheet: View {
                     Button("Done") { dismiss() }
                 }
             }
+        }
+    }
+
+    /// Single Mac-permission row. Green check when granted; red cross when not,
+    /// and tapping a denied row asks the Mac to open the matching System Settings
+    /// pane via `OpenMacSettingsPaneMessage`. Granted rows aren't tappable —
+    /// nothing useful happens there and we don't want to bounce the Mac into
+    /// Settings on accidental taps.
+    @ViewBuilder
+    private func macPermRow(name: String, icon: String, granted: Bool, pane: MacSettingsPane) -> some View {
+        let row = HStack(spacing: 10) {
+            Image(systemName: icon)
+                .font(.system(size: 14))
+                .frame(width: 20)
+                .foregroundStyle(.secondary)
+            Text(name)
+            Spacer()
+            Image(systemName: granted ? "checkmark.circle.fill" : "xmark.circle.fill")
+                .font(.system(size: 16))
+                .foregroundStyle(granted ? Color.green : Color.red)
+            if !granted {
+                Image(systemName: "chevron.right")
+                    .font(.system(size: 11, weight: .semibold))
+                    .foregroundStyle(.tertiary)
+            }
+        }
+        if granted {
+            row
+        } else {
+            Button { client.send(OpenMacSettingsPaneMessage(pane: pane)) } label: { row }
+                .buttonStyle(.plain)
         }
     }
 

--- a/QuipiOS/QuipApp.swift
+++ b/QuipiOS/QuipApp.swift
@@ -2929,7 +2929,7 @@ enum QuickButton: String, CaseIterable, Identifiable {
     //   Slash commands (sends "/foo"),
     //   Claude Code answers (Y/N and number choices),
     //   Terminal keystrokes (Esc, Ctrl-C, Ctrl-D, Tab, Backspace).
-    case plan, btw, compact, clearContext, prd
+    case slash, plan, btw, compact, clearContext, prd
     case yes, no, one, two, three
     case esc, ctrlC, ctrlD, tab, backspace, clearInput
     case planMode, shiftTab
@@ -2938,6 +2938,7 @@ enum QuickButton: String, CaseIterable, Identifiable {
 
     var displayName: String {
         switch self {
+        case .slash: return "/"
         case .plan: return "/plan"
         case .btw: return "/btw"
         case .compact: return "/compact"
@@ -2963,6 +2964,7 @@ enum QuickButton: String, CaseIterable, Identifiable {
     /// which shows in Settings).
     var label: String {
         switch self {
+        case .slash: return "/"
         case .plan: return "/plan"
         case .btw: return "/btw"
         case .compact: return "/compact"
@@ -3015,7 +3017,7 @@ enum QuickButton: String, CaseIterable, Identifiable {
 
     var category: Category {
         switch self {
-        case .plan, .btw, .compact, .clearContext, .prd, .planMode: return .slash
+        case .slash, .plan, .btw, .compact, .clearContext, .prd, .planMode: return .slash
         case .yes, .no, .one, .two, .three: return .answer
         case .esc, .ctrlC, .ctrlD, .tab, .backspace, .clearInput, .shiftTab: return .keystroke
         }
@@ -3023,6 +3025,10 @@ enum QuickButton: String, CaseIterable, Identifiable {
 
     var action: Action {
         switch self {
+        // Bare "/" — opens Claude Code's slash command palette so the user
+        // can pick one via autocomplete. No trailing space (unlike /plan,
+        // /btw, /prd) so Claude's Ink dropdown fires immediately.
+        case .slash: return .sendText("/", pressReturn: false)
         case .plan: return .sendText("/plan ", pressReturn: false)
         case .btw: return .sendText("/btw ", pressReturn: false)
         // /compact auto-submits because unlike /plan or /btw it doesn't

--- a/QuipiOS/QuipApp.swift
+++ b/QuipiOS/QuipApp.swift
@@ -2702,6 +2702,9 @@ struct InlineTerminalContent: View {
     var onSendAction: (String) -> Void
     @Environment(\.quipColors) private var colors
     @AppStorage("tintContentBorder") private var tintContentBorder = true
+    /// Toggle for the tap-to-open URL tray. Default on. Users who don't want
+    /// the extra row between header and screenshot can hide it from Settings.
+    @AppStorage("urlTrayEnabled") private var urlTrayEnabled = true
     /// Zoom level index into `ContentZoomLevel.allCases`. Persisted so the
     /// user's pick survives relaunch, and shared between portrait and
     /// landscape views so cycling in one affects both.
@@ -2747,7 +2750,7 @@ struct InlineTerminalContent: View {
     /// vertical real estate. Each pill: tap → `UIApplication.shared.open`.
     @ViewBuilder
     private var urlTray: some View {
-        if !urls.isEmpty {
+        if urlTrayEnabled && !urls.isEmpty {
             ScrollView(.horizontal, showsIndicators: false) {
                 HStack(spacing: 6) {
                     ForEach(urls, id: \.self) { url in
@@ -2757,12 +2760,12 @@ struct InlineTerminalContent: View {
                             }
                         } label: {
                             Text(urlTrayLabel(for: url))
-                                .font(.system(size: 11, weight: .medium, design: .monospaced))
+                                .font(.system(size: 9.5, weight: .medium, design: .monospaced))
                                 .lineLimit(1)
                                 .truncationMode(.middle)
                                 .foregroundStyle(Color.cyan)
-                                .padding(.horizontal, 8)
-                                .padding(.vertical, 4)
+                                .padding(.horizontal, 7)
+                                .padding(.vertical, 3)
                                 .background(Color.cyan.opacity(0.15))
                                 .clipShape(Capsule())
                                 .overlay(
@@ -3068,6 +3071,7 @@ struct SettingsSheet: View {
     var pushRegistration: PushRegistrationService
     var macPermissions: MacPermissionsMessage?
     @AppStorage("tintContentBorder") private var tintContentBorder = true
+    @AppStorage("urlTrayEnabled") private var urlTrayEnabled = true
     @AppStorage("pushPaused") private var pushPaused = false
     @AppStorage("pushBannerEnabled") private var pushBannerEnabled = true
     @AppStorage("pushSound") private var pushSound = true
@@ -3129,6 +3133,7 @@ struct SettingsSheet: View {
                 // feature's self-explanatory so the page stops feeling padded.
                 Section("Appearance") {
                     Toggle("Tint content panel border", isOn: $tintContentBorder)
+                    Toggle("URL tray", isOn: $urlTrayEnabled)
                 }
 
                 // Notifications — one section. Kill switch on top; the

--- a/QuipiOS/QuipApp.swift
+++ b/QuipiOS/QuipApp.swift
@@ -1632,21 +1632,37 @@ struct MainiOSView: View {
                     let yesNo = enabled.filter { $0 == .yes || $0 == .no }
                     let numbers = enabled.filter { $0 == .one || $0 == .two || $0 == .three }
                     let keystroke = enabled.filter { $0.category == .keystroke }
-                    HStack(spacing: 5) {
-                        ForEach(slash) { quickActionButton($0) }
-                        Spacer(minLength: 8)
-                        ForEach(yesNo) { quickActionButton($0) }
-                        // Small fixed gap between Y/N (confirmations) and
-                        // 1/2/3 (numbered choices) — both are "answers" but
-                        // visually distinct sub-groups.
-                        if !yesNo.isEmpty, !numbers.isEmpty {
-                            Spacer().frame(width: 10)
+                    // `ViewThatFits` tries the spacer-based cluster layout
+                    // first (slash-left / answers-center / keystroke-right,
+                    // aesthetic and aligned with the mic above) and falls
+                    // back to a horizontally-scrollable tight row when too
+                    // many buttons are enabled to fit the phone's width.
+                    // Before this, the cluster row silently overflowed —
+                    // rightmost keystroke buttons got clipped offscreen.
+                    ViewThatFits(in: .horizontal) {
+                        HStack(spacing: 5) {
+                            ForEach(slash) { quickActionButton($0) }
+                            Spacer(minLength: 8)
+                            ForEach(yesNo) { quickActionButton($0) }
+                            // Small fixed gap between Y/N (confirmations)
+                            // and 1/2/3 (numbered choices) — both are
+                            // "answers" but visually distinct sub-groups.
+                            if !yesNo.isEmpty, !numbers.isEmpty {
+                                Spacer().frame(width: 10)
+                            }
+                            ForEach(numbers) { quickActionButton($0) }
+                            Spacer(minLength: 8)
+                            ForEach(keystroke) { quickActionButton($0) }
                         }
-                        ForEach(numbers) { quickActionButton($0) }
-                        Spacer(minLength: 8)
-                        ForEach(keystroke) { quickActionButton($0) }
+                        .padding(.horizontal, 8)
+
+                        ScrollView(.horizontal, showsIndicators: false) {
+                            HStack(spacing: 4) {
+                                ForEach(enabled) { quickActionButton($0) }
+                            }
+                            .padding(.horizontal, 8)
+                        }
                     }
-                    .padding(.horizontal, 8)
                 }
             }
         }

--- a/QuipiOS/QuipApp.swift
+++ b/QuipiOS/QuipApp.swift
@@ -2842,8 +2842,8 @@ struct SettingsSheet: View {
                 // Mac Status — TCC permissions Quip needs on the Mac side.
                 // Tap a red row to pop the right System Settings pane open
                 // remotely so the user doesn't have to dig for it.
-                if let perms = macPermissions {
-                    Section {
+                Section {
+                    if let perms = macPermissions {
                         macPermRow(name: "Accessibility",
                                    icon: "accessibility",
                                    granted: perms.accessibility,
@@ -2856,12 +2856,27 @@ struct SettingsSheet: View {
                                    icon: "rectangle.dashed",
                                    granted: perms.screenRecording,
                                    pane: .screenRecording)
-                    } header: {
-                        Text("Mac Permissions")
-                    } footer: {
-                        if !(perms.accessibility && perms.appleEvents && perms.screenRecording) {
-                            Text("Tap a red row — Mac will pop the right System Settings pane open.")
+                    } else {
+                        // No snapshot yet — likely the Mac hasn't sent one
+                        // since the phone connected, or this Mac build
+                        // predates Phase 1. Show the placeholder explicitly
+                        // so the user (and we) can tell "missing" from
+                        // "all-granted-no-section".
+                        HStack {
+                            Image(systemName: "questionmark.circle")
+                                .foregroundStyle(.secondary)
+                            Text("Waiting for Mac…")
+                                .foregroundStyle(.secondary)
                         }
+                    }
+                } header: {
+                    Text("Mac Permissions")
+                } footer: {
+                    if let perms = macPermissions,
+                       !(perms.accessibility && perms.appleEvents && perms.screenRecording) {
+                        Text("Tap a red row — Mac will pop the right System Settings pane open.")
+                    } else if macPermissions == nil {
+                        Text("If this never updates, the Mac may be on an older build that doesn't broadcast permission status.")
                     }
                 }
 

--- a/QuipiOS/QuipApp.swift
+++ b/QuipiOS/QuipApp.swift
@@ -353,7 +353,18 @@ struct QuipApp: App {
             DispatchQueue.main.async {
                 terminalContentWindowId = windowId
                 terminalContentText = content
-                terminalContentScreenshot = screenshot
+                // Preserve last-good screenshot when the new update doesn't
+                // carry one — happens on Mac Screen Recording revocation
+                // (cdhash change after a Mac rebuild), Tailscale reconnects,
+                // network switches, or momentary Mac CPU spikes where
+                // screencapture returns nil. Without this, the iOS panel
+                // would drop to "Loading…" on every bad refresh even though
+                // the window state hasn't actually changed. Window switches
+                // still clear via `selectedWindowId.onChange` so we never
+                // show stale content from the wrong window.
+                if let screenshot, !screenshot.isEmpty {
+                    terminalContentScreenshot = screenshot
+                }
                 terminalContentURLs = urls
             }
         }
@@ -2739,26 +2750,24 @@ struct InlineTerminalContent: View {
     /// flip the priority again.
     enum RenderBranch { case image, text, loading }
 
-    /// Priority: screenshot > text > loading.
+    /// Priority: screenshot > loading. The `.text` branch is never selected
+    /// by this function in production — monospace plain text hides Claude
+    /// Code's TUI (alt-screen buffer) and loses ANSI colors, which is the
+    /// exact failure mode the user was seeing when Screen Recording got
+    /// revoked on a Mac rebuild. "Loading…" is a better empty state than
+    /// showing the scraped scrollback text.
     ///
-    /// Screenshot wins because Claude Code renders its UI in the terminal's
-    /// alternate screen buffer (the bordered input box), and the Mac's
-    /// text scrape (`readContent` in QuipMacApp.swift) only returns the
-    /// main scrollback buffer — text mode would hide the thing users are
-    /// actually looking at. The screenshot captures pixels regardless of
-    /// buffer and preserves ANSI colors.
+    /// The URL tray above the content still renders regardless of branch,
+    /// so tappable URLs remain available even while waiting for a screenshot.
     ///
-    /// URLs in the image are pixels and can't be tapped in-situ. That's
-    /// why the header renders a tap-to-open URL tray from the Mac's
-    /// `TerminalURLExtractor` — Claude Code emits plenty of URLs in its
-    /// regular output (commit links, docs references, error URLs) and the
-    /// tray makes them openable without losing the screenshot.
+    /// The `.text` enum case is kept so the render switch stays exhaustive
+    /// (defensive — if something external ever returns it, we render safely)
+    /// but `branch(...)` itself returns only `.image` or `.loading`.
     static func branch(content: String, screenshot: String?) -> RenderBranch {
         if let screenshot, let data = Data(base64Encoded: screenshot),
            UIImage(data: data) != nil {
             return .image
         }
-        if !content.isEmpty { return .text }
         return .loading
     }
 

--- a/QuipiOS/QuipApp.swift
+++ b/QuipiOS/QuipApp.swift
@@ -2750,24 +2750,21 @@ struct InlineTerminalContent: View {
     /// flip the priority again.
     enum RenderBranch { case image, text, loading }
 
-    /// Priority: screenshot > loading. The `.text` branch is never selected
-    /// by this function in production — monospace plain text hides Claude
-    /// Code's TUI (alt-screen buffer) and loses ANSI colors, which is the
-    /// exact failure mode the user was seeing when Screen Recording got
-    /// revoked on a Mac rebuild. "Loading…" is a better empty state than
-    /// showing the scraped scrollback text.
+    /// Priority: image > text > loading. Image is the normal state and
+    /// the one the state layer works hard to preserve (last-good screenshot
+    /// caching so network blips don't kick us out). Text is the acceptable
+    /// fallback when no screenshot has ever been received — user's stated
+    /// preference is "plain text beats an empty Loading screen." Loading
+    /// is the truly-no-content state (first connect, between window switches).
     ///
     /// The URL tray above the content still renders regardless of branch,
     /// so tappable URLs remain available even while waiting for a screenshot.
-    ///
-    /// The `.text` enum case is kept so the render switch stays exhaustive
-    /// (defensive — if something external ever returns it, we render safely)
-    /// but `branch(...)` itself returns only `.image` or `.loading`.
     static func branch(content: String, screenshot: String?) -> RenderBranch {
         if let screenshot, let data = Data(base64Encoded: screenshot),
            UIImage(data: data) != nil {
             return .image
         }
+        if !content.isEmpty { return .text }
         return .loading
     }
 

--- a/QuipiOS/QuipApp.swift
+++ b/QuipiOS/QuipApp.swift
@@ -2835,6 +2835,7 @@ enum QuickButton: String, CaseIterable, Identifiable {
     case plan, btw, compact, clearContext, prd
     case yes, no, one, two, three
     case esc, ctrlC, ctrlD, tab, backspace, clearInput
+    case planMode, shiftTab
 
     var id: String { rawValue }
 
@@ -2856,6 +2857,8 @@ enum QuickButton: String, CaseIterable, Identifiable {
         case .tab: return "Tab"
         case .backspace: return "Backspace"
         case .clearInput: return "Clear input"
+        case .planMode: return "→Plan mode"
+        case .shiftTab: return "Shift+Tab"
         }
     }
 
@@ -2879,6 +2882,8 @@ enum QuickButton: String, CaseIterable, Identifiable {
         case .tab: return "Tab"
         case .backspace: return ""
         case .clearInput: return ""
+        case .planMode: return ""
+        case .shiftTab: return ""
         }
     }
 
@@ -2890,6 +2895,8 @@ enum QuickButton: String, CaseIterable, Identifiable {
         case .ctrlD: return "eject"
         case .tab: return "arrow.right.to.line"
         case .clearInput: return "delete.left.fill"
+        case .planMode: return "wand.and.stars"
+        case .shiftTab: return "arrow.left.to.line"
         default: return nil
         }
     }
@@ -2911,9 +2918,9 @@ enum QuickButton: String, CaseIterable, Identifiable {
 
     var category: Category {
         switch self {
-        case .plan, .btw, .compact, .clearContext, .prd: return .slash
+        case .plan, .btw, .compact, .clearContext, .prd, .planMode: return .slash
         case .yes, .no, .one, .two, .three: return .answer
-        case .esc, .ctrlC, .ctrlD, .tab, .backspace, .clearInput: return .keystroke
+        case .esc, .ctrlC, .ctrlD, .tab, .backspace, .clearInput, .shiftTab: return .keystroke
         }
     }
 
@@ -2940,6 +2947,14 @@ enum QuickButton: String, CaseIterable, Identifiable {
         case .tab: return .quickAction("press_tab")
         case .backspace: return .quickAction("press_backspace")
         case .clearInput: return .quickAction("clear_input")
+        // Mac side reads the detected Claude mode for the target window and
+        // sends just enough Shift+Tab presses to reach plan mode (cycle order:
+        // normal → autoAccept → plan → normal). Falls back to an ErrorMessage
+        // toast on the phone when the mode isn't yet detected.
+        case .planMode: return .quickAction("set_plan_mode")
+        // Raw Shift+Tab — manual fallback when mode auto-detect is unreliable
+        // or the user wants to step through the cycle one mode at a time.
+        case .shiftTab: return .quickAction("press_shift_tab")
         }
     }
 

--- a/QuipiOS/QuipApp.swift
+++ b/QuipiOS/QuipApp.swift
@@ -2432,6 +2432,24 @@ struct AttentionPulseDot: View {
     }
 }
 
+/// Wrap http(s) URLs in the terminal content with `.link` attributes so SwiftUI's
+/// `Text` renders them as tappable. Bare domains aren't matched on purpose —
+/// `NSDataDetector` would false-positive on file paths like `Sources/Foo.swift`.
+private func linkifiedTerminalContent(_ raw: String) -> AttributedString {
+    var attr = AttributedString(raw)
+    guard let detector = try? NSDataDetector(types: NSTextCheckingResult.CheckingType.link.rawValue) else {
+        return attr
+    }
+    let ns = raw as NSString
+    detector.enumerateMatches(in: raw, options: [], range: NSRange(location: 0, length: ns.length)) { match, _, _ in
+        guard let match, let url = match.url,
+              let range = Range(match.range, in: attr) else { return }
+        attr[range].link = url
+        attr[range].underlineStyle = .single
+    }
+    return attr
+}
+
 struct InlineTerminalContent: View {
     let content: String
     let screenshot: String?
@@ -2503,7 +2521,7 @@ struct InlineTerminalContent: View {
                             .frame(maxWidth: .infinity)
                             .id("bottom")
                     } else if !content.isEmpty {
-                        Text(content)
+                        Text(linkifiedTerminalContent(content))
                             .font(.system(size: 10, design: .monospaced))
                             .foregroundStyle(.white.opacity(0.85))
                             .frame(maxWidth: .infinity, alignment: .leading)

--- a/QuipiOS/QuipApp.swift
+++ b/QuipiOS/QuipApp.swift
@@ -71,6 +71,13 @@ struct QuipApp: App {
     /// certainly want the island card too. Flipping it off tears down
     /// any in-flight activity (see `.onChange` below).
     @AppStorage("liveActivitiesEnabled") private var liveActivitiesEnabled = true
+    /// Quiet-hours window for Live Activities. Live Activities bypass the
+    /// Mac's APNs prefs (WebSocket-driven, not APNs), so the quiet-hours
+    /// check is duplicated here instead of relying on the Mac-side gate.
+    /// Start/end are 0-23 hours in the phone's local TZ.
+    @AppStorage("pushQuietHoursEnabled") private var quietHoursEnabled = false
+    @AppStorage("pushQuietHoursStart") private var quietHoursStart = 22
+    @AppStorage("pushQuietHoursEnd") private var quietHoursEnd = 7
     /// Output delta text per window — used to display TTS overlay captions
     @State private var ttsOverlayTexts: [String: String] = [:]
     /// Pending image attachment — hoisted to QuipApp (from MainiOSView) so
@@ -199,6 +206,20 @@ struct QuipApp: App {
         }
     }
 
+    /// True when the current wall-clock hour falls inside the user's
+    /// quiet-hours window. Handles both same-day (9-17) and overnight
+    /// (22-7) ranges. Mirrors the Mac-side `DevicePushPreferences.isQuietNow`
+    /// so both the APNs path and the Live Activity path agree.
+    private func isInQuietHoursNow(now: Date = Date(), calendar: Calendar = .current) -> Bool {
+        guard quietHoursEnabled else { return false }
+        let hour = calendar.component(.hour, from: now)
+        if quietHoursStart == quietHoursEnd { return false }
+        if quietHoursStart < quietHoursEnd {
+            return hour >= quietHoursStart && hour < quietHoursEnd
+        }
+        return hour >= quietHoursStart || hour < quietHoursEnd
+    }
+
     private func setup() {
         speech.requestAuthorization()
 
@@ -278,12 +299,18 @@ struct QuipApp: App {
                     // window gets an island; every other thinking window is
                     // tracked by the Mac but doesn't pop its own activity.
                     if windowId == selectedWindowId, liveActivitiesEnabled {
-                        switch newState {
-                        case "thinking":
-                            liveActivity.startOrUpdate(windowId: windowId, windowName: w.name, state: "thinking")
-                        case "waiting_for_input":
-                            liveActivity.startOrUpdate(windowId: windowId, windowName: w.name, state: "waiting")
-                        default:
+                        // During quiet hours, suppress start/update so no new
+                        // island card pops and existing cards stop changing
+                        // state. `end` still fires on neutral so anything that
+                        // started before quiet hours can clean itself up.
+                        let islandState: String? = switch newState {
+                        case "thinking": "thinking"
+                        case "waiting_for_input": "waiting"
+                        default: nil
+                        }
+                        if let islandState, !isInQuietHoursNow() {
+                            liveActivity.startOrUpdate(windowId: windowId, windowName: w.name, state: islandState)
+                        } else if islandState == nil {
                             // neutral or anything else: user is actively engaged
                             // with the terminal; no need for an island card.
                             liveActivity.end(windowId: windowId)
@@ -364,7 +391,8 @@ struct QuipApp: App {
                                 quietHoursEnd: qhEnabled ? (ud.object(forKey: "pushQuietHoursEnd") as? Int ?? 7) : nil,
                                 sound: ud.object(forKey: "pushSound") as? Bool ?? true,
                                 foregroundBanner: ud.bool(forKey: "pushForegroundBanner"),
-                                bannerEnabled: ud.object(forKey: "pushBannerEnabled") as? Bool ?? true
+                                bannerEnabled: ud.object(forKey: "pushBannerEnabled") as? Bool ?? true,
+                                timeZone: TimeZone.current.identifier
                             )
                             client.send(prefs)
                         }
@@ -2858,7 +2886,8 @@ struct SettingsSheet: View {
             quietHoursEnd: quietHoursEnabled ? quietHoursEnd : nil,
             sound: pushSound,
             foregroundBanner: pushForegroundBanner,
-            bannerEnabled: pushBannerEnabled
+            bannerEnabled: pushBannerEnabled,
+            timeZone: TimeZone.current.identifier
         )
         client.send(msg)
     }

--- a/QuipiOS/QuipApp.swift
+++ b/QuipiOS/QuipApp.swift
@@ -2461,9 +2461,10 @@ struct AttentionPulseDot: View {
 }
 
 /// Wrap http(s) URLs in the terminal content with `.link` attributes so SwiftUI's
-/// `Text` renders them as tappable. Bare domains aren't matched on purpose —
-/// `NSDataDetector` would false-positive on file paths like `Sources/Foo.swift`.
-private func linkifiedTerminalContent(_ raw: String) -> AttributedString {
+/// `Text` renders them as tappable. Only matches with an explicit `http://` or
+/// `https://` prefix are linkified — `NSDataDetector` happily matches bare TLDs,
+/// which would turn `README.md` (`.md` is a real TLD) and `Quip.app` into links.
+func linkifiedTerminalContent(_ raw: String) -> AttributedString {
     var attr = AttributedString(raw)
     guard let detector = try? NSDataDetector(types: NSTextCheckingResult.CheckingType.link.rawValue) else {
         return attr
@@ -2472,6 +2473,8 @@ private func linkifiedTerminalContent(_ raw: String) -> AttributedString {
     detector.enumerateMatches(in: raw, options: [], range: NSRange(location: 0, length: ns.length)) { match, _, _ in
         guard let match, let url = match.url,
               let range = Range(match.range, in: attr) else { return }
+        let matched = ns.substring(with: match.range)
+        guard matched.hasPrefix("http://") || matched.hasPrefix("https://") else { return }
         attr[range].link = url
         attr[range].underlineStyle = .single
     }

--- a/QuipiOS/QuipLiveActivity/QuipLiveActivityBundle.swift
+++ b/QuipiOS/QuipLiveActivity/QuipLiveActivityBundle.swift
@@ -1,12 +1,14 @@
 import WidgetKit
 import SwiftUI
 
-/// Widget extension entry point. Single ActivityConfiguration — no
-/// traditional home-screen widgets — because the only surface we use
-/// for push notifications is the Dynamic Island / Live Activity.
+/// Widget extension entry point. Two ActivityConfigurations — no traditional
+/// home-screen widgets — covering the two distinct alert surfaces:
+///   - QuipLiveActivityWidget: per-window thinking/waiting state
+///   - QuipMacPermsActivityWidget: Mac TCC perm needs attention
 @main
 struct QuipLiveActivityBundle: WidgetBundle {
     var body: some Widget {
         QuipLiveActivityWidget()
+        QuipMacPermsActivityWidget()
     }
 }

--- a/QuipiOS/QuipLiveActivity/QuipMacPermsActivityWidget.swift
+++ b/QuipiOS/QuipLiveActivity/QuipMacPermsActivityWidget.swift
@@ -1,0 +1,90 @@
+import ActivityKit
+import WidgetKit
+import SwiftUI
+
+/// Live Activity / Dynamic Island surface for "Mac has TCC perms denied."
+/// Visible from outside the Quip app so the user notices Mac is degraded
+/// without having to open Quip and check the settings sheet.
+///
+/// Tap → deep links to `quip://perms` which pops the SettingsSheet open
+/// directly on the Mac Permissions section.
+struct QuipMacPermsActivityWidget: Widget {
+    var body: some WidgetConfiguration {
+        ActivityConfiguration(for: QuipMacPermsActivityAttributes.self) { context in
+            lockScreenView(context: context)
+                .activityBackgroundTint(Color.black.opacity(0.85))
+                .activitySystemActionForegroundColor(.white)
+        } dynamicIsland: { context in
+            DynamicIsland {
+                DynamicIslandExpandedRegion(.leading) {
+                    Image(systemName: "exclamationmark.triangle.fill")
+                        .font(.system(size: 18))
+                        .foregroundStyle(.red)
+                        .padding(.leading, 8)
+                }
+                DynamicIslandExpandedRegion(.center) {
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text("Mac needs attention")
+                            .font(.headline)
+                        Text(subtitle(for: context.state.deniedCount))
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+                }
+                DynamicIslandExpandedRegion(.trailing) {
+                    Text("\(context.state.deniedCount)")
+                        .font(.system(size: 28, weight: .bold))
+                        .foregroundStyle(.red)
+                        .padding(.trailing, 12)
+                }
+                DynamicIslandExpandedRegion(.bottom) {
+                    Link(destination: URL(string: "quip://perms")!) {
+                        Label("Open Quip", systemImage: "arrow.up.forward.app")
+                            .font(.subheadline.weight(.medium))
+                            .frame(maxWidth: .infinity)
+                    }
+                    .padding(.vertical, 4)
+                }
+            } compactLeading: {
+                Image(systemName: "exclamationmark.triangle.fill")
+                    .font(.system(size: 14))
+                    .foregroundStyle(.red)
+            } compactTrailing: {
+                Text("\(context.state.deniedCount)")
+                    .font(.system(size: 14, weight: .semibold))
+                    .foregroundStyle(.red)
+            } minimal: {
+                Image(systemName: "exclamationmark.triangle.fill")
+                    .font(.system(size: 12))
+                    .foregroundStyle(.red)
+            }
+            .widgetURL(URL(string: "quip://perms"))
+        }
+    }
+
+    @ViewBuilder
+    private func lockScreenView(context: ActivityViewContext<QuipMacPermsActivityAttributes>) -> some View {
+        HStack(spacing: 12) {
+            Image(systemName: "exclamationmark.triangle.fill")
+                .font(.title2)
+                .foregroundStyle(.red)
+            VStack(alignment: .leading, spacing: 2) {
+                Text("Mac needs attention")
+                    .font(.headline)
+                    .foregroundStyle(.white)
+                Text(subtitle(for: context.state.deniedCount))
+                    .font(.caption)
+                    .foregroundStyle(.white.opacity(0.7))
+            }
+            Spacer()
+            Text("\(context.state.deniedCount)")
+                .font(.system(size: 28, weight: .bold))
+                .foregroundStyle(.red)
+        }
+        .padding()
+    }
+
+    private func subtitle(for count: Int) -> String {
+        count == 1 ? "1 permission denied — tap to grant" : "\(count) permissions denied — tap to grant"
+    }
+}

--- a/QuipiOS/QuipLiveActivity/Shared/QuipMacPermsActivityAttributes.swift
+++ b/QuipiOS/QuipLiveActivity/Shared/QuipMacPermsActivityAttributes.swift
@@ -1,0 +1,25 @@
+import Foundation
+import ActivityKit
+
+/// Attributes + dynamic state for the "Mac TCC permission needs attention"
+/// Live Activity. Distinct from `QuipLiveActivityAttributes` (which is per-
+/// window thinking/waiting) because the concerns are different — this one is
+/// global to the Mac, not tied to any iTerm window.
+///
+/// One activity at a time: started when the phone receives a Mac permissions
+/// snapshot with any denied perm, ended when all three are green.
+struct QuipMacPermsActivityAttributes: ActivityAttributes {
+
+    public struct ContentState: Codable, Hashable {
+        /// How many of the three TCC perms are currently denied (0-3). Drives
+        /// the badge count + lockscreen subtitle. ContentState carries no
+        /// per-perm detail — the in-app strip is the source of truth there.
+        public var deniedCount: Int
+
+        public init(deniedCount: Int) {
+            self.deniedCount = deniedCount
+        }
+    }
+
+    public init() {}
+}

--- a/QuipiOS/QuipiOS.xcodeproj/project.pbxproj
+++ b/QuipiOS/QuipiOS.xcodeproj/project.pbxproj
@@ -21,6 +21,7 @@
 		2FE851D3B7E5A263C2E1A06F /* SilentModeDetector.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDFEC177041E6CF5C96C7D88 /* SilentModeDetector.swift */; };
 		390A246B5D13F798E9B55E7B /* ImageRecompressor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D6ED80C8277F668CC0B273C /* ImageRecompressor.swift */; };
 		3C69E42DAC8E6515F9BC3F03 /* WindowManagerSessionIdTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 764505DC63C7C214558A63CC /* WindowManagerSessionIdTests.swift */; };
+		413005C731BCDCED5438E47F /* InlineTerminalContentBranchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD67F0481CA1F97EEB2F5D7C /* InlineTerminalContentBranchTests.swift */; };
 		48F28455B8142325D6833C25 /* QuipTheme.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE693F49CD672CFD1507FDC6 /* QuipTheme.swift */; };
 		4D0689B3D9653512F27A322D /* BonjourBrowser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9EB84DC38B2B261AB78D9B78 /* BonjourBrowser.swift */; };
 		4DD215CB4746FD0FA6D82DD4 /* WebSocketClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5760F08A42C6C6570E49A4B /* WebSocketClient.swift */; };
@@ -96,6 +97,7 @@
 		A76C509CF77201B2EB8B5677 /* KeystrokeFocusDelayTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeystrokeFocusDelayTests.swift; sourceTree = "<group>"; };
 		A8B6A494C62E7118541A81C1 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		AB1FAB05086E60FFC302C3E6 /* ContextMenuView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContextMenuView.swift; sourceTree = "<group>"; };
+		AD67F0481CA1F97EEB2F5D7C /* InlineTerminalContentBranchTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InlineTerminalContentBranchTests.swift; sourceTree = "<group>"; };
 		ADA867C4EE46E8D6EEA5EC8D /* PushRegistrationService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PushRegistrationService.swift; sourceTree = "<group>"; };
 		B3398B602525378B861B9218 /* Signing.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Signing.xcconfig; sourceTree = "<group>"; };
 		B5760F08A42C6C6570E49A4B /* WebSocketClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebSocketClient.swift; sourceTree = "<group>"; };
@@ -182,6 +184,7 @@
 			isa = PBXGroup;
 			children = (
 				F37E465512A160C3F0FE0310 /* ImageRecompressorTests.swift */,
+				AD67F0481CA1F97EEB2F5D7C /* InlineTerminalContentBranchTests.swift */,
 				D6D5159A24459D33F4AE547B /* LinkifiedTerminalContentTests.swift */,
 				FFE14A146132EC2FDBF484D2 /* PTTStressTests.swift */,
 			);
@@ -389,6 +392,7 @@
 				BC0AAA34114426CFF2BEEB74 /* ArrangeLayoutMappingTests.swift in Sources */,
 				2E6A08D65DF1E6DCC0BB7E79 /* ImageRecompressorTests.swift in Sources */,
 				2F94D38C500B41994A45596A /* ImageUploadMessageTests.swift in Sources */,
+				413005C731BCDCED5438E47F /* InlineTerminalContentBranchTests.swift in Sources */,
 				261C1C66A5F75E185F591DD1 /* KeystrokeFocusDelayTests.swift in Sources */,
 				D90497A715C2D1FEBC04B532 /* LinkifiedTerminalContentTests.swift in Sources */,
 				6D05492F589AA379C4DB67BA /* MessageProtocolTests.swift in Sources */,

--- a/QuipiOS/QuipiOS.xcodeproj/project.pbxproj
+++ b/QuipiOS/QuipiOS.xcodeproj/project.pbxproj
@@ -7,14 +7,15 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		035352DA912748C3F99D4D6C /* QuipMacPermsActivityAttributes.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9CD5E023A432434C3093C06 /* QuipMacPermsActivityAttributes.swift */; };
 		046BFBEA924261A691A9EA3B /* PendingImagePreviewStrip.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE0BC3568ECDD8FC3E78B940 /* PendingImagePreviewStrip.swift */; };
+		0DB71EDB9501F21F1248DF62 /* QuipMacPermsActivityWidget.swift in Sources */ = {isa = PBXBuildFile; fileRef = 46181BEC707D4C04671D336E /* QuipMacPermsActivityWidget.swift */; };
 		20FE94C556B5D03097FB0030 /* PreferencesSyncService.swift in Sources */ = {isa = PBXBuildFile; fileRef = D94647DAF2E9DB9470CB5FF5 /* PreferencesSyncService.swift */; };
 		216CB65B0E4953EF7B3C45BA /* LiveActivityService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 731E1A072569A16DBA76D9EB /* LiveActivityService.swift */; };
 		261C1C66A5F75E185F591DD1 /* KeystrokeFocusDelayTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A76C509CF77201B2EB8B5677 /* KeystrokeFocusDelayTests.swift */; };
 		2C52F265432CF7E5BFF28F68 /* QuipLiveActivityAttributes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DE5492ADBC22C9381D58D40 /* QuipLiveActivityAttributes.swift */; };
 		2E3F0351CC5E90C934E0F0B2 /* HardwareButtonHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63A7D08ECBB0B1EFA3F77328 /* HardwareButtonHandler.swift */; };
 		2E6A08D65DF1E6DCC0BB7E79 /* ImageRecompressorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F37E465512A160C3F0FE0310 /* ImageRecompressorTests.swift */; };
-		7F8E9D0C1B2A3F4E5D6C7B8A /* LinkifiedTerminalContentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2E3F4A5C6D7E8F9A0B1C2D3 /* LinkifiedTerminalContentTests.swift */; };
 		2F94D38C500B41994A45596A /* ImageUploadMessageTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DED5CFC890EBB97FEDDAAFC /* ImageUploadMessageTests.swift */; };
 		2FDDC840F5A589B81D2517D0 /* MessageProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE4E6BADD636034CE8C5EC9A /* MessageProtocol.swift */; };
 		2FE851D3B7E5A263C2E1A06F /* SilentModeDetector.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDFEC177041E6CF5C96C7D88 /* SilentModeDetector.swift */; };
@@ -35,6 +36,7 @@
 		90AC9E73F35BAD1CC1917C75 /* QuipLiveActivityBundle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04067ECD7983ACC50844C82D /* QuipLiveActivityBundle.swift */; };
 		911B08CC263A882D5F10E54B /* QuipLiveActivityAttributes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DE5492ADBC22C9381D58D40 /* QuipLiveActivityAttributes.swift */; };
 		996767763A69068B0D1D8687 /* SpeechService.swift in Sources */ = {isa = PBXBuildFile; fileRef = F7EED90216075AC25A1EDB70 /* SpeechService.swift */; };
+		A77BA34594060260386B5501 /* QuipMacPermsActivityAttributes.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9CD5E023A432434C3093C06 /* QuipMacPermsActivityAttributes.swift */; };
 		A977CCC72BA863A04F17FB77 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 07BAAAC4E0E8051B6FF2664E /* Assets.xcassets */; };
 		AC12BD221896070181F785DC /* QuipLiveActivityWidget.swift in Sources */ = {isa = PBXBuildFile; fileRef = 109D3594919D4EF54DE97C72 /* QuipLiveActivityWidget.swift */; };
 		B74D4BBBD664959095BE58DE /* ConnectionStatusBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = F09BCC5DEEA227B256C96191 /* ConnectionStatusBar.swift */; };
@@ -44,6 +46,7 @@
 		C10D61840E80EDAD704827A9 /* Color+Hex.swift in Sources */ = {isa = PBXBuildFile; fileRef = 310DDC8B5BA9B05DA4632BF5 /* Color+Hex.swift */; };
 		CA62A184114B15E2FB535A95 /* MirrorDesktopFilterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BAE6A8EDAED117D04D2161D /* MirrorDesktopFilterTests.swift */; };
 		D574C92B13CDC64E5C200CAB /* PTTStressTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFE14A146132EC2FDBF484D2 /* PTTStressTests.swift */; };
+		D90497A715C2D1FEBC04B532 /* LinkifiedTerminalContentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6D5159A24459D33F4AE547B /* LinkifiedTerminalContentTests.swift */; };
 		E15A8F5B7E6A925B33ECA315 /* KeychainDeviceID.swift in Sources */ = {isa = PBXBuildFile; fileRef = 382370F0C983ABEC82E06430 /* KeychainDeviceID.swift */; };
 		E634311FF9DEAEA0E074302E /* ImagePickerPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3150B50687617E509C16EC1D /* ImagePickerPresenter.swift */; };
 		F7B32FEF1E1A176C2710D831 /* PendingImageState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 773DBA5F5449A8B4C8E7D1AE /* PendingImageState.swift */; };
@@ -76,6 +79,7 @@
 		343D7EF269316EB5B3DCC796 /* MessageProtocolTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageProtocolTests.swift; sourceTree = "<group>"; };
 		382370F0C983ABEC82E06430 /* KeychainDeviceID.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeychainDeviceID.swift; sourceTree = "<group>"; };
 		414AD810B644C175CFB73EE5 /* WindowInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WindowInfo.swift; sourceTree = "<group>"; };
+		46181BEC707D4C04671D336E /* QuipMacPermsActivityWidget.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuipMacPermsActivityWidget.swift; sourceTree = "<group>"; };
 		591693AB60296E1978E9F2D1 /* TerminalContentOverlay.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalContentOverlay.swift; sourceTree = "<group>"; };
 		5DE5492ADBC22C9381D58D40 /* QuipLiveActivityAttributes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuipLiveActivityAttributes.swift; sourceTree = "<group>"; };
 		5DED5CFC890EBB97FEDDAAFC /* ImageUploadMessageTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageUploadMessageTests.swift; sourceTree = "<group>"; };
@@ -99,12 +103,13 @@
 		BE693F49CD672CFD1507FDC6 /* QuipTheme.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuipTheme.swift; sourceTree = "<group>"; };
 		CDEE82AF4A4EEBCF4A0DED50 /* ArrangeLayoutMappingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArrangeLayoutMappingTests.swift; sourceTree = "<group>"; };
 		D1BB453F0473949D38101D3F /* PTTWindowTrackerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PTTWindowTrackerTests.swift; sourceTree = "<group>"; };
+		D6D5159A24459D33F4AE547B /* LinkifiedTerminalContentTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LinkifiedTerminalContentTests.swift; sourceTree = "<group>"; };
 		D94647DAF2E9DB9470CB5FF5 /* PreferencesSyncService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreferencesSyncService.swift; sourceTree = "<group>"; };
 		DDFEC177041E6CF5C96C7D88 /* SilentModeDetector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SilentModeDetector.swift; sourceTree = "<group>"; };
 		E98AE3676ED21B03DFD1861D /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
+		E9CD5E023A432434C3093C06 /* QuipMacPermsActivityAttributes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuipMacPermsActivityAttributes.swift; sourceTree = "<group>"; };
 		F09BCC5DEEA227B256C96191 /* ConnectionStatusBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConnectionStatusBar.swift; sourceTree = "<group>"; };
 		F37E465512A160C3F0FE0310 /* ImageRecompressorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageRecompressorTests.swift; sourceTree = "<group>"; };
-		B2E3F4A5C6D7E8F9A0B1C2D3 /* LinkifiedTerminalContentTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LinkifiedTerminalContentTests.swift; sourceTree = "<group>"; };
 		F7EED90216075AC25A1EDB70 /* SpeechService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpeechService.swift; sourceTree = "<group>"; };
 		FE4E6BADD636034CE8C5EC9A /* MessageProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageProtocol.swift; sourceTree = "<group>"; };
 		FFE14A146132EC2FDBF484D2 /* PTTStressTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PTTStressTests.swift; sourceTree = "<group>"; };
@@ -177,7 +182,7 @@
 			isa = PBXGroup;
 			children = (
 				F37E465512A160C3F0FE0310 /* ImageRecompressorTests.swift */,
-				B2E3F4A5C6D7E8F9A0B1C2D3 /* LinkifiedTerminalContentTests.swift */,
+				D6D5159A24459D33F4AE547B /* LinkifiedTerminalContentTests.swift */,
 				FFE14A146132EC2FDBF484D2 /* PTTStressTests.swift */,
 			);
 			path = Tests;
@@ -206,6 +211,7 @@
 				E98AE3676ED21B03DFD1861D /* Info.plist */,
 				04067ECD7983ACC50844C82D /* QuipLiveActivityBundle.swift */,
 				109D3594919D4EF54DE97C72 /* QuipLiveActivityWidget.swift */,
+				46181BEC707D4C04671D336E /* QuipMacPermsActivityWidget.swift */,
 				FE7D4ADA99A2E83B8E27F724 /* Shared */,
 			);
 			path = QuipLiveActivity;
@@ -252,6 +258,7 @@
 			isa = PBXGroup;
 			children = (
 				5DE5492ADBC22C9381D58D40 /* QuipLiveActivityAttributes.swift */,
+				E9CD5E023A432434C3093C06 /* QuipMacPermsActivityAttributes.swift */,
 			);
 			path = Shared;
 			sourceTree = "<group>";
@@ -370,6 +377,8 @@
 				911B08CC263A882D5F10E54B /* QuipLiveActivityAttributes.swift in Sources */,
 				90AC9E73F35BAD1CC1917C75 /* QuipLiveActivityBundle.swift in Sources */,
 				AC12BD221896070181F785DC /* QuipLiveActivityWidget.swift in Sources */,
+				A77BA34594060260386B5501 /* QuipMacPermsActivityAttributes.swift in Sources */,
+				0DB71EDB9501F21F1248DF62 /* QuipMacPermsActivityWidget.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -379,9 +388,9 @@
 			files = (
 				BC0AAA34114426CFF2BEEB74 /* ArrangeLayoutMappingTests.swift in Sources */,
 				2E6A08D65DF1E6DCC0BB7E79 /* ImageRecompressorTests.swift in Sources */,
-				7F8E9D0C1B2A3F4E5D6C7B8A /* LinkifiedTerminalContentTests.swift in Sources */,
 				2F94D38C500B41994A45596A /* ImageUploadMessageTests.swift in Sources */,
 				261C1C66A5F75E185F591DD1 /* KeystrokeFocusDelayTests.swift in Sources */,
+				D90497A715C2D1FEBC04B532 /* LinkifiedTerminalContentTests.swift in Sources */,
 				6D05492F589AA379C4DB67BA /* MessageProtocolTests.swift in Sources */,
 				CA62A184114B15E2FB535A95 /* MirrorDesktopFilterTests.swift in Sources */,
 				D574C92B13CDC64E5C200CAB /* PTTStressTests.swift in Sources */,
@@ -412,6 +421,7 @@
 				67348F3277C90D577C7D95D3 /* PushRegistrationService.swift in Sources */,
 				6441F32153F6E86CF6529571 /* QuipApp.swift in Sources */,
 				2C52F265432CF7E5BFF28F68 /* QuipLiveActivityAttributes.swift in Sources */,
+				035352DA912748C3F99D4D6C /* QuipMacPermsActivityAttributes.swift in Sources */,
 				48F28455B8142325D6833C25 /* QuipTheme.swift in Sources */,
 				B86CDE99611F63E70CB7C7A3 /* RemoteLayoutView.swift in Sources */,
 				2FE851D3B7E5A263C2E1A06F /* SilentModeDetector.swift in Sources */,

--- a/QuipiOS/QuipiOS.xcodeproj/project.pbxproj
+++ b/QuipiOS/QuipiOS.xcodeproj/project.pbxproj
@@ -14,6 +14,7 @@
 		2C52F265432CF7E5BFF28F68 /* QuipLiveActivityAttributes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DE5492ADBC22C9381D58D40 /* QuipLiveActivityAttributes.swift */; };
 		2E3F0351CC5E90C934E0F0B2 /* HardwareButtonHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63A7D08ECBB0B1EFA3F77328 /* HardwareButtonHandler.swift */; };
 		2E6A08D65DF1E6DCC0BB7E79 /* ImageRecompressorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F37E465512A160C3F0FE0310 /* ImageRecompressorTests.swift */; };
+		7F8E9D0C1B2A3F4E5D6C7B8A /* LinkifiedTerminalContentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2E3F4A5C6D7E8F9A0B1C2D3 /* LinkifiedTerminalContentTests.swift */; };
 		2F94D38C500B41994A45596A /* ImageUploadMessageTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DED5CFC890EBB97FEDDAAFC /* ImageUploadMessageTests.swift */; };
 		2FDDC840F5A589B81D2517D0 /* MessageProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE4E6BADD636034CE8C5EC9A /* MessageProtocol.swift */; };
 		2FE851D3B7E5A263C2E1A06F /* SilentModeDetector.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDFEC177041E6CF5C96C7D88 /* SilentModeDetector.swift */; };
@@ -103,6 +104,7 @@
 		E98AE3676ED21B03DFD1861D /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		F09BCC5DEEA227B256C96191 /* ConnectionStatusBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConnectionStatusBar.swift; sourceTree = "<group>"; };
 		F37E465512A160C3F0FE0310 /* ImageRecompressorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageRecompressorTests.swift; sourceTree = "<group>"; };
+		B2E3F4A5C6D7E8F9A0B1C2D3 /* LinkifiedTerminalContentTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LinkifiedTerminalContentTests.swift; sourceTree = "<group>"; };
 		F7EED90216075AC25A1EDB70 /* SpeechService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpeechService.swift; sourceTree = "<group>"; };
 		FE4E6BADD636034CE8C5EC9A /* MessageProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageProtocol.swift; sourceTree = "<group>"; };
 		FFE14A146132EC2FDBF484D2 /* PTTStressTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PTTStressTests.swift; sourceTree = "<group>"; };
@@ -175,6 +177,7 @@
 			isa = PBXGroup;
 			children = (
 				F37E465512A160C3F0FE0310 /* ImageRecompressorTests.swift */,
+				B2E3F4A5C6D7E8F9A0B1C2D3 /* LinkifiedTerminalContentTests.swift */,
 				FFE14A146132EC2FDBF484D2 /* PTTStressTests.swift */,
 			);
 			path = Tests;
@@ -376,6 +379,7 @@
 			files = (
 				BC0AAA34114426CFF2BEEB74 /* ArrangeLayoutMappingTests.swift in Sources */,
 				2E6A08D65DF1E6DCC0BB7E79 /* ImageRecompressorTests.swift in Sources */,
+				7F8E9D0C1B2A3F4E5D6C7B8A /* LinkifiedTerminalContentTests.swift in Sources */,
 				2F94D38C500B41994A45596A /* ImageUploadMessageTests.swift in Sources */,
 				261C1C66A5F75E185F591DD1 /* KeystrokeFocusDelayTests.swift in Sources */,
 				6D05492F589AA379C4DB67BA /* MessageProtocolTests.swift in Sources */,

--- a/QuipiOS/Services/HardwareButtonHandler.swift
+++ b/QuipiOS/Services/HardwareButtonHandler.swift
@@ -63,6 +63,15 @@ final class HardwareButtonHandler {
             DispatchQueue.main.async { [weak self] in
                 guard let self else { return }
 
+                // Don't touch volume or interpret presses unless Quip is actually
+                // foreground-active. KVO keeps firing while .inactive (app switcher,
+                // Control Center, lock-screen peek) and between willResignActive
+                // and didEnterBackground — hitting restoreVolume() in that window
+                // fights whatever app the user is actually using (YouTube etc.).
+                // We deliberately do NOT tear down the observer or audio session
+                // here; that path broke PTT resume before.
+                guard UIApplication.shared.applicationState == .active else { return }
+
                 // Ignore phantom KVO events caused by audio session reconfiguration
                 guard Date() >= self.suppressUntil else { return }
 

--- a/QuipiOS/Services/LiveActivityService.swift
+++ b/QuipiOS/Services/LiveActivityService.swift
@@ -16,6 +16,9 @@ import Observation
 @Observable
 final class LiveActivityService {
     private var activities: [String: Activity<QuipLiveActivityAttributes>] = [:]
+    /// Single global activity for the "Mac TCC perms degraded" alert.
+    /// Distinct from per-window activities — there's only ever one Mac.
+    private var macPermsActivity: Activity<QuipMacPermsActivityAttributes>?
 
     /// True if Live Activities are usable on this device. False on
     /// iPhones without Dynamic Island (iPhone 13 and earlier), when
@@ -42,6 +45,20 @@ final class LiveActivityService {
     nonisolated func endAll() {
         Task { @MainActor in
             await self.endAllAsync()
+        }
+    }
+
+    /// Start or update the Mac-perms degraded activity. Pass `deniedCount`
+    /// (1-3) to refresh the badge; passing 0 ends the activity.
+    nonisolated func startOrUpdateMacPerms(deniedCount: Int) {
+        Task { @MainActor in
+            await self.startOrUpdateMacPermsAsync(deniedCount: deniedCount)
+        }
+    }
+
+    nonisolated func endMacPerms() {
+        Task { @MainActor in
+            await self.endMacPermsAsync()
         }
     }
 
@@ -90,7 +107,8 @@ final class LiveActivityService {
 
     /// End every activity — used on sign-out / connection loss so the
     /// island doesn't show stale "waiting" state for a window the Mac
-    /// no longer reports.
+    /// no longer reports. Also tears down the Mac-perms alert because a
+    /// disconnected phone has nothing useful to say about Mac state.
     private func endAllAsync() async {
         let all = activities
         activities.removeAll()
@@ -100,5 +118,40 @@ final class LiveActivityService {
                 dismissalPolicy: .immediate
             )
         }
+        await endMacPermsAsync()
+    }
+
+    private func startOrUpdateMacPermsAsync(deniedCount: Int) async {
+        guard areActivitiesEnabled else {
+            print("[LiveActivity] mac-perms skipped (activities not enabled)")
+            return
+        }
+        guard deniedCount > 0 else {
+            await endMacPermsAsync()
+            return
+        }
+        let newContent = QuipMacPermsActivityAttributes.ContentState(deniedCount: deniedCount)
+        if let existing = macPermsActivity {
+            await existing.update(ActivityContent(state: newContent, staleDate: nil))
+            return
+        }
+        do {
+            macPermsActivity = try Activity.request(
+                attributes: QuipMacPermsActivityAttributes(),
+                content: ActivityContent(state: newContent, staleDate: nil),
+                pushType: nil
+            )
+        } catch {
+            print("[LiveActivity] mac-perms start failed: \(error)")
+        }
+    }
+
+    private func endMacPermsAsync() async {
+        guard let activity = macPermsActivity else { return }
+        macPermsActivity = nil
+        await activity.end(
+            ActivityContent(state: activity.content.state, staleDate: nil),
+            dismissalPolicy: .immediate
+        )
     }
 }

--- a/QuipiOS/Services/WebSocketClient.swift
+++ b/QuipiOS/Services/WebSocketClient.swift
@@ -497,21 +497,34 @@ final class WebSocketClient {
         }
     }
 
-    /// Ping the server every 10 seconds. If a ping fails, tear down and reconnect.
-    /// The tighter interval (vs the old 30s) surfaces dead connections within ~10-15s
-    /// so the phone shows "disconnected" quickly instead of silently swallowing taps.
+    /// Ping the server every 10s and *await the pong* with a 3s timeout.
+    /// Two consecutive missed pongs → treat the socket as dead and reconnect.
+    ///
+    /// The previous fire-and-forget `sendPing` only flipped to disconnected on a
+    /// local send error. One-sided drops (Mac restart, NAT idle timeout, Cloudflare
+    /// tunnel rotation) leave the callback hanging silently — pong never arrives,
+    /// no error fires, and the UI shows "Connected" forever. Worst case to detect
+    /// a real disconnect is now ~13s (10s interval + 3s pong timeout) instead of
+    /// "until iOS or the OS notices TCP is dead," which can take many minutes on
+    /// cellular.
     private func startKeepalive() {
         keepaliveTask?.cancel()
         keepaliveTask = Task { [weak self] in
+            var consecutiveMisses = 0
             while !Task.isCancelled {
                 try? await Task.sleep(nanoseconds: 10_000_000_000)
                 guard !Task.isCancelled, let self, let task = self.webSocketTask else { return }
-                task.sendPing { error in
-                    DispatchQueue.main.async {
-                        if let error {
-                            NSLog("[WebSocketClient] Keepalive ping failed: %@", error.localizedDescription)
-                            self.handleDisconnect()
-                        }
+                let pongReceived = await Self.probeSocket(task: task, timeoutNanos: 3_000_000_000)
+                guard !Task.isCancelled else { return }
+                if pongReceived {
+                    consecutiveMisses = 0
+                } else {
+                    consecutiveMisses += 1
+                    NSLog("[WebSocketClient] Keepalive pong missed (%d/2)", consecutiveMisses)
+                    if consecutiveMisses >= 2 {
+                        NSLog("[WebSocketClient] Two consecutive missed pongs — forcing reconnect")
+                        self.handleDisconnect()
+                        return
                     }
                 }
             }

--- a/QuipiOS/Services/WebSocketClient.swift
+++ b/QuipiOS/Services/WebSocketClient.swift
@@ -127,6 +127,9 @@ final class WebSocketClient {
     /// Mac is sending back a preferences snapshot the phone previously
     /// uploaded — used to repopulate UserDefaults after a reinstall.
     var onPreferencesRestore: ((PreferencesSnapshot) -> Void)?
+    /// Mac sent its current TCC permission status. Phone surfaces it in the
+    /// settings sheet + as a badge on the main screen when anything is denied.
+    var onMacPermissions: ((MacPermissionsMessage) -> Void)?
     /// Mac confirms an image upload; argument is the absolute path the Mac wrote.
     var onImageUploadAck: ((String) -> Void)?
     /// Mac rejects an image upload; argument is a human-readable reason.
@@ -491,6 +494,11 @@ final class WebSocketClient {
             guard isAuthenticated else { return }
             if let msg = try? decoder.decode(ImageUploadErrorMessage.self, from: data) {
                 onImageUploadError?(msg.reason)
+            }
+        case "mac_permissions":
+            guard isAuthenticated else { return }
+            if let msg = try? decoder.decode(MacPermissionsMessage.self, from: data) {
+                onMacPermissions?(msg)
             }
         default:
             NSLog("[WebSocketClient] Unknown message type: %@", peek.type)

--- a/QuipiOS/Services/WebSocketClient.swift
+++ b/QuipiOS/Services/WebSocketClient.swift
@@ -110,7 +110,7 @@ final class WebSocketClient {
 
     var onLayoutUpdate: ((LayoutUpdate) -> Void)?
     var onStateChange: ((String, String) -> Void)?
-    var onTerminalContent: ((String, String, String?) -> Void)?  // (windowId, content, screenshot)
+    var onTerminalContent: ((String, String, String?, [String]?) -> Void)?  // (windowId, content, screenshot, urls)
     var onOutputDelta: ((String, String, String, Bool) -> Void)?  // (windowId, windowName, text, isFinal)
     // (windowId, windowName, sessionId, sequence, isFinal, wavData)
     var onTTSAudio: ((String, String, String, Int, Bool, Data) -> Void)?
@@ -444,7 +444,7 @@ final class WebSocketClient {
         case "terminal_content":
             guard isAuthenticated else { return }
             if let msg = try? decoder.decode(TerminalContentMessage.self, from: data) {
-                onTerminalContent?(msg.windowId, msg.content, msg.screenshot)
+                onTerminalContent?(msg.windowId, msg.content, msg.screenshot, msg.urls)
             }
         case "output_delta":
             guard isAuthenticated else { return }

--- a/QuipiOS/Tests/InlineTerminalContentBranchTests.swift
+++ b/QuipiOS/Tests/InlineTerminalContentBranchTests.swift
@@ -34,14 +34,19 @@ final class InlineTerminalContentBranchTests: XCTestCase {
         XCTAssertEqual(b, .image, "screenshot wins over text — Claude TUI is in alt-screen which text scrape misses")
     }
 
-    func test_screenshot_nil_with_text_takes_text_branch() {
+    func test_screenshot_nil_with_text_goes_to_loading() {
+        // Always-image rule: text content alone is never shown as monospace
+        // plain text — the user asked for image mode always. Missing screenshot
+        // means the panel shows "Loading…" until one arrives (or, in practice,
+        // the iOS state layer preserves the last-good screenshot through a
+        // bad refresh, so this case rarely materializes at runtime).
         let b = InlineTerminalContent.branch(content: "some terminal text", screenshot: nil)
-        XCTAssertEqual(b, .text)
+        XCTAssertEqual(b, .loading)
     }
 
-    func test_screenshot_non_decodable_falls_through_to_text() {
+    func test_screenshot_non_decodable_goes_to_loading() {
         let b = InlineTerminalContent.branch(content: "hi", screenshot: "not-base64-at-all!!!")
-        XCTAssertEqual(b, .text, "garbage screenshot payload must not strand the view in image branch")
+        XCTAssertEqual(b, .loading, "garbage screenshot payload must not strand the view in image branch, but we also don't drop to text")
     }
 
     func test_empty_content_no_screenshot_is_loading() {
@@ -55,9 +60,9 @@ final class InlineTerminalContentBranchTests: XCTestCase {
         XCTAssertEqual(b, .image, "screenshot-only windows (non-terminal apps) must render the image")
     }
 
-    func test_base64_that_is_not_an_image_falls_through() {
+    func test_base64_that_is_not_an_image_goes_to_loading() {
         // "hello" base64-encoded — valid base64, invalid PNG/JPEG.
         let b = InlineTerminalContent.branch(content: "body", screenshot: "aGVsbG8=")
-        XCTAssertEqual(b, .text, "base64 that doesn't decode to UIImage must not trap the view in image branch")
+        XCTAssertEqual(b, .loading, "base64 that doesn't decode to UIImage must not trap the view in image branch; always-image policy sends it to loading instead of text")
     }
 }

--- a/QuipiOS/Tests/InlineTerminalContentBranchTests.swift
+++ b/QuipiOS/Tests/InlineTerminalContentBranchTests.swift
@@ -34,19 +34,21 @@ final class InlineTerminalContentBranchTests: XCTestCase {
         XCTAssertEqual(b, .image, "screenshot wins over text — Claude TUI is in alt-screen which text scrape misses")
     }
 
-    func test_screenshot_nil_with_text_goes_to_loading() {
-        // Always-image rule: text content alone is never shown as monospace
-        // plain text — the user asked for image mode always. Missing screenshot
-        // means the panel shows "Loading…" until one arrives (or, in practice,
-        // the iOS state layer preserves the last-good screenshot through a
-        // bad refresh, so this case rarely materializes at runtime).
+    func test_screenshot_nil_with_text_falls_back_to_text() {
+        // Priority is image > text > loading. User's explicit preference is
+        // that plain text beats an empty Loading screen — so when no
+        // screenshot is available but content exists, we render the text
+        // branch. The state layer's last-good-screenshot preservation keeps
+        // this case rare: once any screenshot has been received for the
+        // current window, a subsequent nil-screenshot update doesn't clear
+        // the cached image, so .image stays live.
         let b = InlineTerminalContent.branch(content: "some terminal text", screenshot: nil)
-        XCTAssertEqual(b, .loading)
+        XCTAssertEqual(b, .text)
     }
 
-    func test_screenshot_non_decodable_goes_to_loading() {
+    func test_screenshot_non_decodable_falls_back_to_text() {
         let b = InlineTerminalContent.branch(content: "hi", screenshot: "not-base64-at-all!!!")
-        XCTAssertEqual(b, .loading, "garbage screenshot payload must not strand the view in image branch, but we also don't drop to text")
+        XCTAssertEqual(b, .text, "garbage screenshot payload must not strand the view in image branch; text beats Loading…")
     }
 
     func test_empty_content_no_screenshot_is_loading() {
@@ -60,9 +62,9 @@ final class InlineTerminalContentBranchTests: XCTestCase {
         XCTAssertEqual(b, .image, "screenshot-only windows (non-terminal apps) must render the image")
     }
 
-    func test_base64_that_is_not_an_image_goes_to_loading() {
+    func test_base64_that_is_not_an_image_falls_back_to_text() {
         // "hello" base64-encoded — valid base64, invalid PNG/JPEG.
         let b = InlineTerminalContent.branch(content: "body", screenshot: "aGVsbG8=")
-        XCTAssertEqual(b, .loading, "base64 that doesn't decode to UIImage must not trap the view in image branch; always-image policy sends it to loading instead of text")
+        XCTAssertEqual(b, .text, "base64 that doesn't decode to UIImage falls back to text, not Loading…")
     }
 }

--- a/QuipiOS/Tests/InlineTerminalContentBranchTests.swift
+++ b/QuipiOS/Tests/InlineTerminalContentBranchTests.swift
@@ -1,0 +1,63 @@
+import XCTest
+import UIKit
+@testable import Quip
+
+/// Pins the InlineTerminalContent render-branch decision.
+///
+/// Why this test exists: commit 440b175 shipped the `LinkableTerminalText`
+/// UITextView path assuming it was the live render path. It wasn't — the Mac
+/// always sends a screenshot alongside the text content, iOS's branch
+/// conditional checks `screenshot` first, and the UITextView path only runs
+/// when screenshot capture fails. Covered the linkifier, missed the branch.
+///
+/// These tests pin the mapping so future changes to the priority rule
+/// (e.g. "prefer text for terminal windows") break a test instead of silently
+/// regressing the user experience.
+final class InlineTerminalContentBranchTests: XCTestCase {
+
+    private func pngBase64(size: CGSize = CGSize(width: 8, height: 8)) -> String {
+        let renderer = UIGraphicsImageRenderer(size: size)
+        let img = renderer.image { ctx in
+            UIColor.black.setFill()
+            ctx.fill(CGRect(origin: .zero, size: size))
+        }
+        return img.pngData()!.base64EncodedString()
+    }
+
+    func test_screenshot_present_and_decodes_takes_image_branch() {
+        // Image-first: Claude Code's TUI lives in the alternate screen buffer
+        // which the Mac's text scrape doesn't capture. The screenshot is the
+        // only way to show the input box users actually interact with.
+        // URL linkification lives behind this — tracked as a wishlist item.
+        let png = pngBase64()
+        let b = InlineTerminalContent.branch(content: "some terminal text", screenshot: png)
+        XCTAssertEqual(b, .image, "screenshot wins over text — Claude TUI is in alt-screen which text scrape misses")
+    }
+
+    func test_screenshot_nil_with_text_takes_text_branch() {
+        let b = InlineTerminalContent.branch(content: "some terminal text", screenshot: nil)
+        XCTAssertEqual(b, .text)
+    }
+
+    func test_screenshot_non_decodable_falls_through_to_text() {
+        let b = InlineTerminalContent.branch(content: "hi", screenshot: "not-base64-at-all!!!")
+        XCTAssertEqual(b, .text, "garbage screenshot payload must not strand the view in image branch")
+    }
+
+    func test_empty_content_no_screenshot_is_loading() {
+        let b = InlineTerminalContent.branch(content: "", screenshot: nil)
+        XCTAssertEqual(b, .loading)
+    }
+
+    func test_empty_content_with_screenshot_still_shows_image() {
+        let png = pngBase64()
+        let b = InlineTerminalContent.branch(content: "", screenshot: png)
+        XCTAssertEqual(b, .image, "screenshot-only windows (non-terminal apps) must render the image")
+    }
+
+    func test_base64_that_is_not_an_image_falls_through() {
+        // "hello" base64-encoded — valid base64, invalid PNG/JPEG.
+        let b = InlineTerminalContent.branch(content: "body", screenshot: "aGVsbG8=")
+        XCTAssertEqual(b, .text, "base64 that doesn't decode to UIImage must not trap the view in image branch")
+    }
+}

--- a/QuipiOS/Tests/LinkifiedTerminalContentTests.swift
+++ b/QuipiOS/Tests/LinkifiedTerminalContentTests.swift
@@ -1,0 +1,86 @@
+import XCTest
+import SwiftUI
+@testable import Quip
+
+final class LinkifiedTerminalContentTests: XCTestCase {
+
+    func test_httpsURL_getsLinkAttribute() {
+        let raw = "see https://github.com/anthropic for context"
+        let attr = linkifiedTerminalContent(raw)
+
+        let urlRanges = attr.runs.filter { $0.link != nil }.map { $0.range }
+        XCTAssertEqual(urlRanges.count, 1, "exactly one URL run expected")
+
+        let runRange = try! XCTUnwrap(urlRanges.first)
+        XCTAssertEqual(String(attr[runRange].characters), "https://github.com/anthropic")
+
+        let link = attr[runRange].link
+        XCTAssertEqual(link?.absoluteString, "https://github.com/anthropic")
+    }
+
+    func test_httpURL_getsLinkAttribute() {
+        let raw = "fallback http://example.com here"
+        let attr = linkifiedTerminalContent(raw)
+
+        let runs = attr.runs.filter { $0.link != nil }
+        XCTAssertEqual(runs.count, 1)
+        XCTAssertEqual(runs.first?.link?.absoluteString, "http://example.com")
+    }
+
+    func test_filePath_isNotLinked() {
+        // The whole reason bare-domain matching is disabled — file paths must not turn into links.
+        let raw = "edit Sources/Foo.swift line 42"
+        let attr = linkifiedTerminalContent(raw)
+
+        let linkRuns = attr.runs.filter { $0.link != nil }
+        XCTAssertTrue(linkRuns.isEmpty, "file paths should not be linkified")
+    }
+
+    func test_bareDomain_isNotLinked() {
+        let raw = "go to github.com to clone"
+        let attr = linkifiedTerminalContent(raw)
+
+        let linkRuns = attr.runs.filter { $0.link != nil }
+        XCTAssertTrue(linkRuns.isEmpty, "bare domains without scheme should not be linkified")
+    }
+
+    /// `.md` is Moldova's TLD, so NSDataDetector happily matches `README.md`
+    /// without the scheme filter — exactly the false positive Claude Code output
+    /// would expose constantly.
+    func test_markdownFile_isNotLinked() {
+        let raw = "see README.md for setup"
+        let attr = linkifiedTerminalContent(raw)
+
+        let linkRuns = attr.runs.filter { $0.link != nil }
+        XCTAssertTrue(linkRuns.isEmpty, "README.md must not be linkified")
+    }
+
+    /// `.app` is a real TLD (Google), so `Quip.app` would otherwise become a link.
+    func test_appBundle_isNotLinked() {
+        let raw = "rebuild Quip.app and reinstall"
+        let attr = linkifiedTerminalContent(raw)
+
+        let linkRuns = attr.runs.filter { $0.link != nil }
+        XCTAssertTrue(linkRuns.isEmpty, "Quip.app must not be linkified")
+    }
+
+    func test_multipleURLs_allTagged() {
+        let raw = "https://a.com and https://b.com/path?q=1"
+        let attr = linkifiedTerminalContent(raw)
+
+        let links = attr.runs.compactMap { $0.link?.absoluteString }
+        XCTAssertEqual(Set(links), ["https://a.com", "https://b.com/path?q=1"])
+    }
+
+    func test_emptyString_returnsEmptyAttributedString() {
+        let attr = linkifiedTerminalContent("")
+        XCTAssertEqual(String(attr.characters), "")
+    }
+
+    func test_noURL_returnsPlainAttributedString() {
+        let raw = "just some terminal output, no links"
+        let attr = linkifiedTerminalContent(raw)
+        XCTAssertEqual(String(attr.characters), raw)
+        XCTAssertTrue(attr.runs.allSatisfy { $0.link == nil })
+    }
+}

--- a/QuipiOS/Tests/LinkifiedTerminalContentTests.swift
+++ b/QuipiOS/Tests/LinkifiedTerminalContentTests.swift
@@ -64,6 +64,27 @@ final class LinkifiedTerminalContentTests: XCTestCase {
         XCTAssertTrue(linkRuns.isEmpty, "Quip.app must not be linkified")
     }
 
+    /// Bare email addresses — NSDataDetector returns them as `mailto:` URLs.
+    /// We accept those so a tap pops the system Mail compose sheet. Claude
+    /// prints contact addresses in commit-author lines + OAuth notices, so
+    /// this is a high-yield extension of the http(s) link path.
+    func test_bareEmail_isLinkedAsMailto() {
+        let raw = "contact noreply@anthropic.com for support"
+        let attr = linkifiedTerminalContent(raw)
+
+        let links = attr.runs.compactMap { $0.link?.absoluteString }
+        XCTAssertEqual(links, ["mailto:noreply@anthropic.com"])
+    }
+
+    /// Explicit `mailto:` URI in the text — should also link.
+    func test_explicitMailto_isLinked() {
+        let raw = "or use mailto:hi@example.com directly"
+        let attr = linkifiedTerminalContent(raw)
+
+        let links = attr.runs.compactMap { $0.link?.absoluteString }
+        XCTAssertEqual(links, ["mailto:hi@example.com"])
+    }
+
     func test_multipleURLs_allTagged() {
         let raw = "https://a.com and https://b.com/path?q=1"
         let attr = linkifiedTerminalContent(raw)

--- a/Shared/MessageProtocol.swift
+++ b/Shared/MessageProtocol.swift
@@ -37,16 +37,22 @@ struct WindowState: Codable, Identifiable, Sendable, Equatable, Hashable {
     let color: String
     /// True when Claude/node processes are running in this window's terminal
     let isThinking: Bool
+    /// Claude Code mode scraped from terminal content. One of "normal", "plan",
+    /// "autoAccept", or nil if unknown / not yet detected / not a Claude window.
+    /// Optional for backward compat; old Mac builds just won't populate it.
+    let claudeMode: String?
 
     // Synthesized Equatable compares ALL fields including frame
 
-    /// Backward-compat: default isThinking to false if missing from JSON
+    /// Backward-compat: default isThinking to false and claudeMode to nil if missing from JSON
     init(id: String, name: String, app: String, folder: String? = nil, enabled: Bool,
-         frame: WindowFrame, state: String, color: String, isThinking: Bool = false) {
+         frame: WindowFrame, state: String, color: String, isThinking: Bool = false,
+         claudeMode: String? = nil) {
         self.id = id; self.name = name; self.app = app; self.folder = folder
         self.enabled = enabled
         self.frame = frame; self.state = state; self.color = color
         self.isThinking = isThinking
+        self.claudeMode = claudeMode
     }
 
     init(from decoder: Decoder) throws {
@@ -60,11 +66,22 @@ struct WindowState: Codable, Identifiable, Sendable, Equatable, Hashable {
         state = try c.decode(String.self, forKey: .state)
         color = try c.decode(String.self, forKey: .color)
         isThinking = (try? c.decode(Bool.self, forKey: .isThinking)) ?? false
+        claudeMode = try? c.decode(String.self, forKey: .claudeMode)
     }
 
     private enum CodingKeys: String, CodingKey {
-        case id, name, app, folder, enabled, frame, state, color, isThinking
+        case id, name, app, folder, enabled, frame, state, color, isThinking, claudeMode
     }
+}
+
+// MARK: - Claude Code Mode
+
+/// Claude Code's three cyclable modes, scraped from terminal content by
+/// `ClaudeModeDetector` on the Mac. Cycle order (Shift+Tab): normal → autoAccept → plan → normal.
+enum ClaudeMode: String, Codable, Sendable {
+    case normal
+    case plan
+    case autoAccept
 }
 
 struct WindowFrame: Codable, Sendable, Equatable, Hashable {

--- a/Shared/MessageProtocol.swift
+++ b/Shared/MessageProtocol.swift
@@ -82,6 +82,19 @@ enum ClaudeMode: String, Codable, Sendable {
     case normal
     case plan
     case autoAccept
+
+    /// The Shift+Tab cycle order Claude Code uses internally. Order matters —
+    /// `shiftTabPresses(from:to:)` derives press counts from these indices.
+    static let cycle: [ClaudeMode] = [.normal, .autoAccept, .plan]
+
+    /// How many Shift+Tab presses are needed to move from `from` mode to `to` mode
+    /// inside Claude Code's three-mode cycle. 0 if already there. Always returns
+    /// 0…2 (the cycle has length 3, so the longest forward path is 2 presses).
+    static func shiftTabPresses(from: ClaudeMode, to: ClaudeMode) -> Int {
+        guard let fromIdx = cycle.firstIndex(of: from),
+              let toIdx = cycle.firstIndex(of: to) else { return 0 }
+        return (toIdx - fromIdx + cycle.count) % cycle.count
+    }
 }
 
 struct WindowFrame: Codable, Sendable, Equatable, Hashable {

--- a/Shared/MessageProtocol.swift
+++ b/Shared/MessageProtocol.swift
@@ -250,12 +250,19 @@ struct TerminalContentMessage: Codable, Sendable {
     let windowId: String
     let content: String
     let screenshot: String?
+    /// URLs extracted from `content` on the Mac (http/https/mailto only,
+    /// no bare-TLD false positives — same scheme filter as the iOS linkifier).
+    /// Surfaced so iOS can render a tap-to-open URL tray alongside the
+    /// screenshot, which is otherwise pixels and can't be linkified.
+    /// Optional for backwards compat with pre-tray Mac builds.
+    let urls: [String]?
 
-    init(windowId: String, content: String, screenshot: String? = nil) {
+    init(windowId: String, content: String, screenshot: String? = nil, urls: [String]? = nil) {
         self.type = "terminal_content"
         self.windowId = windowId
         self.content = content
         self.screenshot = screenshot
+        self.urls = urls
     }
 }
 

--- a/Shared/MessageProtocol.swift
+++ b/Shared/MessageProtocol.swift
@@ -576,6 +576,53 @@ struct AuthResultMessage: Codable, Sendable {
     }
 }
 
+// MARK: - Mac Permission Status
+
+/// One of the macOS TCC panes Quip needs the user to grant. The phone sends this
+/// back via `OpenMacSettingsPaneMessage` so the Mac can pop the right pane open
+/// without the user hunting through System Settings.
+enum MacSettingsPane: String, Codable, Sendable, CaseIterable {
+    case accessibility
+    case automation
+    case screenRecording
+}
+
+/// Mac → iPhone. Snapshot of what's currently granted on the Mac. Sent on
+/// startup, on each new client auth, and every 5s while a client is connected.
+/// Local Network is intentionally omitted — if you can read this message at all,
+/// Local Network is working.
+struct MacPermissionsMessage: Codable, Sendable, Equatable {
+    let type: String
+    let accessibility: Bool
+    /// Apple Events / Automation grant for iTerm specifically. Probed via
+    /// `AEDeterminePermissionToAutomateTarget(askUserIfNeeded: false)` against
+    /// iTerm's bundle ID. If iTerm isn't running we report `true` rather than
+    /// false-alarm — the alternative is a red dot every time the user hasn't
+    /// launched iTerm yet.
+    let appleEvents: Bool
+    let screenRecording: Bool
+
+    init(accessibility: Bool, appleEvents: Bool, screenRecording: Bool) {
+        self.type = "mac_permissions"
+        self.accessibility = accessibility
+        self.appleEvents = appleEvents
+        self.screenRecording = screenRecording
+    }
+}
+
+/// iPhone → Mac. Tap-to-open shortcut: Mac calls `NSWorkspace.shared.open(...)`
+/// with the matching `x-apple.systempreferences:` URL so the right pane pops up
+/// without the user navigating System Settings manually.
+struct OpenMacSettingsPaneMessage: Codable, Sendable {
+    let type: String
+    let pane: MacSettingsPane
+
+    init(pane: MacSettingsPane) {
+        self.type = "open_mac_settings_pane"
+        self.pane = pane
+    }
+}
+
 // MARK: - Message Encoding/Decoding Helpers
 
 enum MessageCoder {

--- a/Shared/MessageProtocol.swift
+++ b/Shared/MessageProtocol.swift
@@ -608,6 +608,12 @@ struct MacPermissionsMessage: Codable, Sendable, Equatable {
         self.appleEvents = appleEvents
         self.screenRecording = screenRecording
     }
+
+    /// 0-3 — number of perms currently denied. Used by the Live Activity badge
+    /// and by the in-app sheet's "any denied" footer.
+    var deniedCount: Int {
+        (accessibility ? 0 : 1) + (appleEvents ? 0 : 1) + (screenRecording ? 0 : 1)
+    }
 }
 
 /// iPhone → Mac. Tap-to-open shortcut: Mac calls `NSWorkspace.shared.open(...)`

--- a/Shared/MessageProtocol.swift
+++ b/Shared/MessageProtocol.swift
@@ -415,7 +415,8 @@ struct RegisterPushDeviceMessage: Codable, Sendable {
 /// device token so a shared account with two phones behaves independently.
 ///
 /// `quietHoursStart` / `quietHoursEnd` are hours of day (0-23) in the
-/// user's local time zone. nil = quiet hours disabled.
+/// phone's local time zone (identified by `timeZone`).
+/// nil start/end = quiet hours disabled.
 struct PushPreferencesMessage: Codable, Sendable {
     let type: String
     let deviceToken: String
@@ -431,9 +432,17 @@ struct PushPreferencesMessage: Codable, Sendable {
     /// so older iOS clients (that don't know about this field) still decode
     /// cleanly as banner-on.
     let bannerEnabled: Bool?
+    /// IANA time-zone identifier (e.g. "America/Phoenix") for the phone
+    /// that set these prefs. The Mac uses it to evaluate `quietHoursStart`/
+    /// `End` against the user's intent rather than the Mac's own TZ, which
+    /// matters when the two machines aren't co-located (travel, VPS host).
+    /// Optional so older iOS clients decode cleanly — the Mac falls back
+    /// to its own `Calendar.current` in that case.
+    let timeZone: String?
 
     init(deviceToken: String, paused: Bool, quietHoursStart: Int?, quietHoursEnd: Int?,
-         sound: Bool, foregroundBanner: Bool, bannerEnabled: Bool? = nil) {
+         sound: Bool, foregroundBanner: Bool, bannerEnabled: Bool? = nil,
+         timeZone: String? = nil) {
         self.type = "push_preferences"
         self.deviceToken = deviceToken
         self.paused = paused
@@ -442,6 +451,7 @@ struct PushPreferencesMessage: Codable, Sendable {
         self.sound = sound
         self.foregroundBanner = foregroundBanner
         self.bannerEnabled = bannerEnabled
+        self.timeZone = timeZone
     }
 }
 

--- a/Shared/Tests/MessageProtocolTests.swift
+++ b/Shared/Tests/MessageProtocolTests.swift
@@ -517,6 +517,39 @@ final class MessageProtocolTests: XCTestCase {
         XCTAssertEqual(ClaudeMode.autoAccept.rawValue, "autoAccept")
     }
 
+    // MARK: - Claude Mode Cycle Math (#6)
+
+    func testShiftTabPressesNoMovementWhenAlreadyOnTarget() {
+        XCTAssertEqual(ClaudeMode.shiftTabPresses(from: .normal, to: .normal), 0)
+        XCTAssertEqual(ClaudeMode.shiftTabPresses(from: .plan, to: .plan), 0)
+        XCTAssertEqual(ClaudeMode.shiftTabPresses(from: .autoAccept, to: .autoAccept), 0)
+    }
+
+    func testShiftTabPressesForwardThroughCycle() {
+        // Cycle order: normal → autoAccept → plan → normal
+        XCTAssertEqual(ClaudeMode.shiftTabPresses(from: .normal, to: .autoAccept), 1)
+        XCTAssertEqual(ClaudeMode.shiftTabPresses(from: .autoAccept, to: .plan), 1)
+        XCTAssertEqual(ClaudeMode.shiftTabPresses(from: .plan, to: .normal), 1)
+    }
+
+    func testShiftTabPressesWrapsAround() {
+        // Two presses needed when target is one step "behind" current
+        XCTAssertEqual(ClaudeMode.shiftTabPresses(from: .normal, to: .plan), 2)
+        XCTAssertEqual(ClaudeMode.shiftTabPresses(from: .autoAccept, to: .normal), 2)
+        XCTAssertEqual(ClaudeMode.shiftTabPresses(from: .plan, to: .autoAccept), 2)
+    }
+
+    func testShiftTabPressesAlwaysInRange() {
+        // Cycle length is 3 — no path can ever require >2 presses.
+        for from in ClaudeMode.cycle {
+            for to in ClaudeMode.cycle {
+                let presses = ClaudeMode.shiftTabPresses(from: from, to: to)
+                XCTAssertGreaterThanOrEqual(presses, 0)
+                XCTAssertLessThanOrEqual(presses, 2, "Cycle of length 3 should never need >2 presses, got \(presses) for \(from) → \(to)")
+            }
+        }
+    }
+
     func testLayoutUpdateRoundTripWithScreenAspect() throws {
         let original = LayoutUpdate(
             monitor: "Built-in",

--- a/Shared/Tests/MessageProtocolTests.swift
+++ b/Shared/Tests/MessageProtocolTests.swift
@@ -475,6 +475,48 @@ final class MessageProtocolTests: XCTestCase {
         XCTAssertEqual(original, restored)
     }
 
+    func testWindowStateBackwardCompatWithoutClaudeMode() throws {
+        // Old Mac builds don't populate `claudeMode` — verify the decoder
+        // defaults it to nil and all other fields survive.
+        let json = """
+        {
+          "id": "w1",
+          "name": "Terminal",
+          "app": "Terminal",
+          "enabled": true,
+          "frame": { "x": 0.0, "y": 0.0, "width": 1.0, "height": 1.0 },
+          "state": "neutral",
+          "color": "#FFFFFF",
+          "isThinking": false
+        }
+        """.data(using: .utf8)!
+
+        let state = try XCTUnwrap(MessageCoder.decode(WindowState.self, from: json))
+        XCTAssertNil(state.claudeMode, "claudeMode should default to nil when absent")
+    }
+
+    func testWindowStateRoundTripWithClaudeMode() throws {
+        let original = WindowState(
+            id: "w3", name: "claude", app: "iTerm2", folder: "Quip",
+            enabled: true,
+            frame: WindowFrame(x: 0, y: 0, width: 1, height: 1),
+            state: "neutral", color: "#00FF00", isThinking: true,
+            claudeMode: "plan"
+        )
+        let data = try XCTUnwrap(MessageCoder.encode(original))
+        let restored = try XCTUnwrap(MessageCoder.decode(WindowState.self, from: data))
+        XCTAssertEqual(restored.claudeMode, "plan")
+        XCTAssertEqual(original, restored)
+    }
+
+    func testClaudeModeRawValues() {
+        // Cross-platform JSON key stability — iOS, Mac, and Android all match
+        // on these raw strings, so changing them is a protocol break.
+        XCTAssertEqual(ClaudeMode.normal.rawValue, "normal")
+        XCTAssertEqual(ClaudeMode.plan.rawValue, "plan")
+        XCTAssertEqual(ClaudeMode.autoAccept.rawValue, "autoAccept")
+    }
+
     func testLayoutUpdateRoundTripWithScreenAspect() throws {
         let original = LayoutUpdate(
             monitor: "Built-in",

--- a/Shared/Tests/MessageProtocolTests.swift
+++ b/Shared/Tests/MessageProtocolTests.swift
@@ -591,6 +591,38 @@ final class MessageProtocolTests: XCTestCase {
         XCTAssertNil(decoded.quietHoursEnd)
     }
 
+    /// The phone sets its TZ alongside quiet hours so the Mac can evaluate
+    /// "10 PM" in the phone's clock, not the Mac's — matters when the two
+    /// aren't co-located. Older iOS clients omit the field, and we verify
+    /// it round-trips both ways.
+    func testPushPreferencesMessageCarriesTimeZone() throws {
+        let msg = PushPreferencesMessage(
+            deviceToken: "TKN",
+            paused: false,
+            quietHoursStart: 22,
+            quietHoursEnd: 7,
+            sound: true,
+            foregroundBanner: false,
+            bannerEnabled: true,
+            timeZone: "America/Phoenix"
+        )
+        let data = try XCTUnwrap(MessageCoder.encode(msg))
+        let decoded = try XCTUnwrap(MessageCoder.decode(PushPreferencesMessage.self, from: data))
+        XCTAssertEqual(decoded.timeZone, "America/Phoenix")
+
+        let legacy = PushPreferencesMessage(
+            deviceToken: "TKN",
+            paused: false,
+            quietHoursStart: nil,
+            quietHoursEnd: nil,
+            sound: true,
+            foregroundBanner: false
+        )
+        let legacyData = try XCTUnwrap(MessageCoder.encode(legacy))
+        let legacyDecoded = try XCTUnwrap(MessageCoder.decode(PushPreferencesMessage.self, from: legacyData))
+        XCTAssertNil(legacyDecoded.timeZone)
+    }
+
     // MARK: - Helpers
 
     private func jsonDict(from data: Data) throws -> [String: Any] {

--- a/Shared/Tests/MessageProtocolTests.swift
+++ b/Shared/Tests/MessageProtocolTests.swift
@@ -625,6 +625,44 @@ final class MessageProtocolTests: XCTestCase {
 
     // MARK: - Helpers
 
+    // MARK: - Mac permissions / settings-pane messages
+
+    func testMacPermissionsEncoding() throws {
+        let msg = MacPermissionsMessage(accessibility: true, appleEvents: false, screenRecording: true)
+        let data = try XCTUnwrap(MessageCoder.encode(msg))
+        let dict = try jsonDict(from: data)
+
+        XCTAssertEqual(dict["type"] as? String, "mac_permissions")
+        XCTAssertEqual(dict["accessibility"] as? Bool, true)
+        XCTAssertEqual(dict["appleEvents"] as? Bool, false)
+        XCTAssertEqual(dict["screenRecording"] as? Bool, true)
+    }
+
+    func testMacPermissionsRoundTrip() throws {
+        let msg = MacPermissionsMessage(accessibility: false, appleEvents: true, screenRecording: false)
+        let data = try XCTUnwrap(MessageCoder.encode(msg))
+        let decoded = try XCTUnwrap(MessageCoder.decode(MacPermissionsMessage.self, from: data))
+        XCTAssertEqual(decoded, msg)
+    }
+
+    func testOpenMacSettingsPaneEncoding() throws {
+        for pane in MacSettingsPane.allCases {
+            let msg = OpenMacSettingsPaneMessage(pane: pane)
+            let data = try XCTUnwrap(MessageCoder.encode(msg))
+            let dict = try jsonDict(from: data)
+
+            XCTAssertEqual(dict["type"] as? String, "open_mac_settings_pane")
+            XCTAssertEqual(dict["pane"] as? String, pane.rawValue)
+        }
+    }
+
+    func testOpenMacSettingsPaneRoundTrip() throws {
+        let msg = OpenMacSettingsPaneMessage(pane: .accessibility)
+        let data = try XCTUnwrap(MessageCoder.encode(msg))
+        let decoded = try XCTUnwrap(MessageCoder.decode(OpenMacSettingsPaneMessage.self, from: data))
+        XCTAssertEqual(decoded.pane, .accessibility)
+    }
+
     private func jsonDict(from data: Data) throws -> [String: Any] {
         try XCTUnwrap(
             JSONSerialization.jsonObject(with: data) as? [String: Any]

--- a/Shared/Tests/WindowManagerSessionIdTests.swift
+++ b/Shared/Tests/WindowManagerSessionIdTests.swift
@@ -22,7 +22,8 @@ final class WindowManagerSessionIdTests: XCTestCase {
             pid: 1,
             windowNumber: windowNumber,
             bounds: bounds,
-            iterm2SessionId: nil
+            iterm2SessionId: nil,
+            iterm2Tty: nil
         )
     }
 
@@ -41,8 +42,8 @@ final class WindowManagerSessionIdTests: XCTestCase {
         ]
 
         wm.applyIterm2SessionIds([
-            WindowManager.Iterm2SessionInfo(bounds: boundsA, uuid: "UUID-A"),
-            WindowManager.Iterm2SessionInfo(bounds: boundsB, uuid: "UUID-B")
+            WindowManager.Iterm2SessionInfo(bounds: boundsA, uuid: "UUID-A", tty: "ttys001"),
+            WindowManager.Iterm2SessionInfo(bounds: boundsB, uuid: "UUID-B", tty: "ttys002")
         ])
 
         XCTAssertEqual(wm.windows[0].iterm2SessionId, "UUID-A",
@@ -63,7 +64,7 @@ final class WindowManagerSessionIdTests: XCTestCase {
         ]
 
         wm.applyIterm2SessionIds([
-            WindowManager.Iterm2SessionInfo(bounds: boundsInList, uuid: "UUID-X")
+            WindowManager.Iterm2SessionInfo(bounds: boundsInList, uuid: "UUID-X", tty: "ttys003")
         ])
 
         XCTAssertNil(wm.windows[0].iterm2SessionId,
@@ -108,7 +109,8 @@ final class WindowManagerSessionIdTests: XCTestCase {
             pid: terminalWindow.pid,
             windowNumber: terminalWindow.windowNumber,
             bounds: terminalWindow.bounds,
-            iterm2SessionId: nil
+            iterm2SessionId: nil,
+            iterm2Tty: nil
         )
         _ = terminalWindow // silence unused
         wm.windows = [mirrored]
@@ -129,7 +131,7 @@ final class WindowManagerSessionIdTests: XCTestCase {
         ]
 
         wm.applyIterm2SessionIds([
-            WindowManager.Iterm2SessionInfo(bounds: applescriptBounds, uuid: "UUID-CLOSE")
+            WindowManager.Iterm2SessionInfo(bounds: applescriptBounds, uuid: "UUID-CLOSE", tty: "ttys004")
         ])
 
         XCTAssertEqual(wm.windows[0].iterm2SessionId, "UUID-CLOSE",

--- a/docs/superpowers/wishlist.md
+++ b/docs/superpowers/wishlist.md
@@ -561,14 +561,6 @@ The 1, 2, 3 quick-action buttons (added in jboert's commit `4e774e6`, tracked un
 
 ---
 
-### 32. `mailto:` link support in terminal content
-
-**Status:** Wishlist
-**Depends on:** #31 (need http(s) working first)
-**Context:** Once the `linkifiedTerminalContent` URL detection actually fires on iOS, extend the scheme filter (`hasPrefix("http://") || hasPrefix("https://")`) to also accept `mailto:`. `NSDataDetector` already detects email-style links; the filter just needs the extra prefix check. Tap → opens Mail compose draft via the system URL handler. One-line code change + 1-2 unit tests.
-
----
-
 ### 33. Mac perms feature — verify all sub-flows in production
 
 **Status:** Wishlist (acceptance testing)
@@ -591,4 +583,8 @@ The 1, 2, 3 quick-action buttons (added in jboert's commit `4e774e6`, tracked un
 
 Diagnosed autonomously via a Node.js fake-iOS-client (`/tmp/quip-content-probe.js`) that auths to the Mac WebSocket, requests terminal content, dumps the raw bytes, and a standalone Swift script (`/tmp/test-linkifier.swift`) that runs the exact `linkifiedTerminalContent` logic against those bytes. That confirmed `raw=6 kept=2` — the linkifier was working correctly all along; the bug was further down the SwiftUI render chain. The earlier "Case B" report was a misread caused by the user testing when no http(s) URLs happened to be in the visible iTerm buffer at that moment.
 
-**Related:** commits `d3bf4c9` (initial linkifier), `b5bb8d7` (scheme filter + tests).
+**Related:** commits `d3bf4c9` (initial linkifier), `b5bb8d7` (scheme filter + tests), `03ebfc9` (the gesture-routing fix).
+
+### 32. `mailto:` link support in terminal content
+
+**Status:** ✅ Done — extended the scheme filter in `linkifiedTerminalContent` to accept `mailto:` substring matches AND any URL whose `scheme` is "mailto" (NSDataDetector returns bare emails like `noreply@anthropic.com` as `mailto:noreply@anthropic.com` URLs natively, so both cases are covered). Two new unit tests: bare-email-as-mailto + explicit-mailto-uri. Tap pops the system Mail compose sheet via the standard URL handler.

--- a/docs/superpowers/wishlist.md
+++ b/docs/superpowers/wishlist.md
@@ -563,13 +563,18 @@ The 1, 2, 3 quick-action buttons (added in jboert's commit `4e774e6`, tracked un
 
 ### 33. Mac perms feature — verify all sub-flows in production
 
-**Status:** Wishlist (acceptance testing)
-**Context:** PR #6 ships Phase 1 + Phase 2 of the Mac TCC perms feature (probe → broadcast → iOS strip → deep-link → Live Activity → auto-pop sheet → Mac UI). End-to-end happy path verified manually (`clients=1 auth=1`, three green checks). Unverified flows worth a deliberate pass before merging or shipping wider:
-- Revoke a perm in System Settings → confirm phone strip flips red within 5s, gear-icon red dot appears, Dynamic Island shows triangle + count
+**Status:** Partially verified (autonomous). Manual checklist below pending user.
+
+**Autonomously verified (this session):** Connected a fake-iOS-client (Node WebSocket) to the Mac, authed with the saved PIN, observed that Mac broadcasts `mac_permissions accessibility=true appleEvents=true screenRecording=true` within ~22ms of auth — the auth-time `force=true` broadcast path is correct, the on-disk Mac binary is sending what Phase 1 designed.
+
+**Pending user (state-change sub-flows + visual confirmation):**
+- Revoke a perm in System Settings → phone strip flips red within 5s, gear-icon red dot appears, Dynamic Island shows triangle + count
 - Tap a red row in iOS SettingsSheet → matching System Settings pane opens on Mac (test all three: Accessibility, Automation, Screen Recording)
-- Tap Dynamic Island banner from Quip-backgrounded state → Quip launches into `quip://perms` deep link → SettingsSheet opens straight on Mac Permissions section
-- Mac UI Settings → General → Permissions section: tap Grant on a denied row → matching pane opens; flip green within 3s of granting (TimelineView refresh)
-- Live Activities toggle in Quip iOS Settings: turning OFF should kill any active perms LA + suppress new ones; turning ON should start one if perms are degraded
+- Tap Dynamic Island banner from Quip-backgrounded state → Quip launches via `quip://perms` deep link → SettingsSheet opens on the Mac Permissions section
+- Mac UI Settings → General → Permissions: tap Grant on a denied row → matching pane opens; flip green within 3s of granting (TimelineView refresh)
+- Live Activities toggle in Quip iOS Settings: turning OFF kills any active perms LA + suppresses new ones; turning ON spawns one if degraded
+
+Skipped autonomous TCC revoke (would force user re-grant — explicitly painful per their saved feedback). Trusting the broadcast pipe verification + Phase 1's prior all-green test until the manual run-through.
 
 **Related:** commits `0f3a0be`, `90e8e1a`, `59cfb3a`. PR https://github.com/jboert/Quip/pull/6.
 

--- a/docs/superpowers/wishlist.md
+++ b/docs/superpowers/wishlist.md
@@ -561,6 +561,39 @@ The 1, 2, 3 quick-action buttons (added in jboert's commit `4e774e6`, tracked un
 
 ---
 
+### 34. iPhone Quip never receives `mac_permissions` despite Mac broadcasting it
+
+**Status:** In Progress (debugging stuck) — eb-branch local
+**Context:** During the autonomous burn-down of #33 we discovered the iPhone Quip app's "Mac Permissions" SettingsSheet section is permanently stuck on "Waiting for Mac…". Captured iOS device console (`xcrun devicectl device process launch --console`) shows iOS receives `auth_result`, `layout_update`, and `project_directories` over WebSocket every ~2s — but **never** receives `mac_permissions`. A parallel Node.js fake-iOS-client (`/tmp/perms-watcher.js` style) connecting to the same Mac WebSocket with the same PIN consistently receives `mac_permissions acc=true ae=true sr=true` within ~22ms of auth. So the broadcast IS going out (proven via Node) but the iPhone specifically isn't seeing it.
+
+**What's been verified:**
+- Build binary HAS `case "mac_permissions":` in `WebSocketClient.swift:498` (confirmed via `nm` + `strings` on the installed `Quip.debug.dylib`).
+- iOS dispatch trace (NSLog at top of `handleMessage`) — never fires for `mac_permissions`. `[ws-trace] received type=mac_permissions` would appear if iOS even saw the type. It doesn't.
+- iOS receives other broadcast types fine (`layout_update`, `project_directories` flow constantly from the same `webSocketServer.broadcast(_:)` Mac-side function).
+- Mac's `broadcastPermissions(force:true)` fires on every `onClientAuthenticated` callback. Both Node and iPhone clients should be in the `clients[]` array at that moment, both auth'd. Yet only Node sees the message.
+
+**Suspected root causes (not yet narrowed):**
+1. Backpressure check in Mac's `broadcast(_:)` (`pendingBytes + payloadSize > maxPendingBytes` at `WebSocketServer.swift:~250`) silently drops the broadcast for the iPhone client only — possible if a stale TTS audio chunk or screenshot send completion never fires for the iPhone connection, accumulating `pendingBytes` past 2MB. But layout_update would also be dropped under that theory and it isn't.
+2. NWConnection-level frame fragmentation specific to LAN clients (iPhone is on `192.168.4.34` over WiFi; Node listener is on `localhost`). Apple's WebSocket implementation may handle frame ordering / queueing differently for the two transports.
+3. The iOS app's WebSocket task queue silently drops messages received during a specific moment of the auth flow — perhaps `mac_permissions` arrives in the same TCP receive buffer as `auth_result` and gets eaten during the "first message marks connected" branch in `receiveNext()` (`WebSocketClient.swift:373-388`).
+
+**Diagnostic infrastructure built (uncommitted, removed before commit):**
+- `/tmp/perms-watcher.js` — long-lived Node WebSocket fake-client that prints every `mac_permissions` it receives.
+- `/tmp/quip-content-probe.js` — one-shot probe that auths + requests terminal_content for a given window name.
+- NSLog `[ws-trace]` at top of `handleMessage` and `[mac_perms-debug]` in dispatch + handler.
+
+**Next steps when resuming:**
+1. Add per-client logging on Mac side inside `webSocketServer.broadcast(_:)` — log payload type + per-client decision (auth'd? skipped due to pendingBytes? sent? completion fired?). Write to `/tmp/quip-broadcast.log`. This makes the broadcast path observable from the Mac terminal without requiring iOS console capture.
+2. Run with both Node listener and iPhone connected, verify which clients get which messages.
+3. If pendingBytes is the culprit, investigate why the iPhone connection accumulates without completion.
+4. If it's NWConnection-specific, file an Apple Feedback or work around with explicit per-message delivery confirmation.
+
+**Workaround idea worth trying first:** add a periodic mac_permissions re-broadcast every 30s with `force=true` (not just on snapshot change). If the iPhone misses the auth-time broadcast for any reason, the next periodic one would catch it.
+
+**Related:** Discovered while burning down #33's autonomous half. Mac binary on disk at `/Applications/Quip.app` (CDHash `c2d7ce61...`). Latest iOS bundle on phone (databaseSequenceNumber 7612) has `[ws-trace]` instrumentation removed.
+
+---
+
 ### 33. Mac perms feature — verify all sub-flows in production
 
 **Status:** Partially verified (autonomous). Manual checklist below pending user.

--- a/docs/superpowers/wishlist.md
+++ b/docs/superpowers/wishlist.md
@@ -561,6 +561,27 @@ The 1, 2, 3 quick-action buttons (added in jboert's commit `4e774e6`, tracked un
 
 ---
 
+### 35. Cross-app paste from iPhone clipboard into Quip terminal
+
+**Status:** Wishlist
+**Context:** User wants to copy text from any iOS app (Safari, Mail, Messages, Notes, ChatGPT, etc.), switch to Quip, and paste it into the currently selected terminal — text gets piped to the Mac via WebSocket and typed into the active iTerm window. Today the iPhone has a text-input field for typed/dictated input but no obvious paste affordance.
+
+**Likely shape:**
+- A paste button (clipboard icon) inline next to the existing text-input bar OR in the QuickButton row.
+- Tapping reads `UIPasteboard.general.string`, sends it via the existing `SendTextMessage` (no new protocol needed), with `pressReturn: false` so the user can review before submitting.
+- Long-press on the paste button could surface options (paste with return, paste raw multi-line, paste as `cat << EOF` heredoc for multi-line code blocks).
+- Visual feedback on tap: brief "Pasted N chars" toast or button flash.
+
+**Open questions for /prd time:**
+- Paste size cap — iOS clipboard can hold MBs; cap at e.g. 32KB for terminal sanity?
+- Multi-line paste handling — does Mac inject as one chunk via `write text`, or line-by-line?
+- Dedicated UI affordance vs. invoke via long-press on the existing input bar?
+- Do we want the inverse direction too (copy terminal selection → iPhone clipboard)?
+
+**Related:** Existing `SendTextMessage` protocol path (`Shared/MessageProtocol.swift`); existing `keystrokeInjector.sendText` on Mac side; existing dictation/text-input UI in `portraitControls`.
+
+---
+
 ### 34. iPhone Quip never receives `mac_permissions` despite Mac broadcasting it
 
 **Status:** In Progress (debugging stuck) — eb-branch local

--- a/docs/superpowers/wishlist.md
+++ b/docs/superpowers/wishlist.md
@@ -31,14 +31,12 @@ A one-tap button on the iPhone remote that types `/plan ` into the currently sel
 
 ### 2. Add / close terminal tabs from the iPhone remote
 
-**Status:** Wishlist
-**Context:** The iPhone currently cycles through existing Claude Code terminal windows via the left/right chevron buttons but cannot create or destroy them. The user wants to open new Claude Code sessions and close existing ones directly from the phone. Implementation will need:
-- New message types in `Shared/MessageProtocol.swift` (e.g., `OpenWindowMessage`, `CloseWindowMessage`).
-- Mac-side AppleScript for spawning a new Terminal.app / iTerm2 window running `claude`, and a close-window handler.
-- iPhone UI affordances — probably `+` and `×` buttons attached to the window list, or a pair of new shortcut buttons in `portraitControls`.
-- A decision about what "close a tab" means when a Claude Code session has unsaved state.
+**Status:** ✅ Done — retroactively. Both halves shipped via larger follow-on features that subsumed this entry:
+- **Open-new-tab:** `SpawnWindowMessage` via the project-directory picker — shipped under #29 on `eb-branch` (commits `5b35c71`, `24fee2d`, `2320170`). `QuipiOS/QuipApp.swift:981` fires the message when the user taps a project; `QuipMac/QuipMacApp.swift:842` handles it and auto-selects the new window.
+- **Close-tab:** `CloseWindowMessage` via the per-window context menu's "Close terminal…" item with destructive alert confirmation — shipped under the duplicate/close feature (commits `44033ee → 75c2b95`). `QuipiOS/Views/WindowRectangle.swift:184` fires the message from the confirmation alert's destructive button; `QuipMac/QuipMacApp.swift:828` handles it with a windowId lookup + `ErrorMessage` broadcast on drop. The context menu also offers "Remove from Phone" (soft-delete via `toggleEnabled`) to separate "hide the terminal from the phone" from "kill the terminal session."
 
-User asked for this explicitly as a separate feature from `/plan`.
+**Original context** (kept for historical reference):
+The iPhone currently cycles through existing Claude Code terminal windows via the left/right chevron buttons but cannot create or destroy them. The user wants to open new Claude Code sessions and close existing ones directly from the phone. User asked for this explicitly as a separate feature from `/plan`.
 
 ---
 
@@ -78,9 +76,16 @@ Known risk: without mode detection, blind Shift+Tab presses can land in the wron
 
 ### 7. Read Claude Code mode from terminal content stream
 
-**Status:** Wishlist
-**Context:** Parse the terminal content stream (already flowing via `TerminalContentMessage` / `OutputDeltaMessage` on the existing websocket protocol) to detect Claude Code's current mode indicator strings — `plan mode on`, `auto-accept edits on`, or the absence of either (= Normal mode). Exposes Claude Code's internal mode state to Quip's UI.
-**Unlocks:** #6 (robust Shift+Tab plan-mode switching), #18 (context-aware 1/2/3 prompt-response buttons), visible mode indicator on the iPhone status area, intelligent prompt routing decisions.
+**Status:** ✅ Done — shipped on `eb-branch` (2026-04-20). New `ClaudeModeDetector` service on the Mac polls each tracked window's iTerm buffer every 2s, scans the last ~40 lines for `plan mode on` / `auto-accept edits on`, and exposes the result via a new optional `claudeMode: String?` field on the `WindowState` protocol struct (raw values: `"normal"`, `"plan"`, `"autoAccept"`). On mode change, `broadcastLayout()` re-fires so iOS sees the new state within one poll cycle.
+
+**Files:** `Shared/MessageProtocol.swift` (added `ClaudeMode` enum + `claudeMode` field with backward-compat decoder), `QuipMac/Services/ClaudeModeDetector.swift` (new), `QuipMac/Services/WindowManager.swift` (`toWindowState` accepts mode), `QuipMac/QuipMacApp.swift` (instantiate, wire `onModeChange` → `broadcastLayout`, mirror tracked-window set, prune on `syncTrackedWindows`).
+
+**Tests:** `Shared/Tests/MessageProtocolTests.swift` (round-trip + backward-compat for `claudeMode`), `QuipMac/Tests/ClaudeModeScannerTests.swift` (scanner unit tests covering plan, autoAccept, normal-as-nil, empty, tail-window cutoff for old-prose mentions, both-strings-plan-wins, case insensitivity). 116 Mac tests pass; iOS build green.
+
+**Unlocks:** #6 (robust Shift+Tab plan-mode switching), #18 (context-aware 1/2/3 prompt-response buttons), visible mode indicator on the iPhone status area, intelligent prompt routing decisions. iOS doesn't yet *consume* the field — that lands when #18 (or a v2 status indicator) implements it.
+
+**Original context** (kept for historical reference):
+Parse the terminal content stream to detect Claude Code's current mode indicator strings — `plan mode on`, `auto-accept edits on`, or the absence of either (= Normal mode). Exposes Claude Code's internal mode state to Quip's UI.
 
 ---
 

--- a/docs/superpowers/wishlist.md
+++ b/docs/superpowers/wishlist.md
@@ -561,6 +561,34 @@ The 1, 2, 3 quick-action buttons (added in jboert's commit `4e774e6`, tracked un
 
 ---
 
+### 32. `mailto:` link support in terminal content
+
+**Status:** Wishlist
+**Depends on:** #31 (need http(s) working first)
+**Context:** Once the `linkifiedTerminalContent` URL detection actually fires on iOS, extend the scheme filter (`hasPrefix("http://") || hasPrefix("https://")`) to also accept `mailto:`. `NSDataDetector` already detects email-style links; the filter just needs the extra prefix check. Tap → opens Mail compose draft via the system URL handler. One-line code change + 1-2 unit tests.
+
+---
+
+### 33. Mac perms feature — verify all sub-flows in production
+
+**Status:** Wishlist (acceptance testing)
+**Context:** PR #6 ships Phase 1 + Phase 2 of the Mac TCC perms feature (probe → broadcast → iOS strip → deep-link → Live Activity → auto-pop sheet → Mac UI). End-to-end happy path verified manually (`clients=1 auth=1`, three green checks). Unverified flows worth a deliberate pass before merging or shipping wider:
+- Revoke a perm in System Settings → confirm phone strip flips red within 5s, gear-icon red dot appears, Dynamic Island shows triangle + count
+- Tap a red row in iOS SettingsSheet → matching System Settings pane opens on Mac (test all three: Accessibility, Automation, Screen Recording)
+- Tap Dynamic Island banner from Quip-backgrounded state → Quip launches into `quip://perms` deep link → SettingsSheet opens straight on Mac Permissions section
+- Mac UI Settings → General → Permissions section: tap Grant on a denied row → matching pane opens; flip green within 3s of granting (TimelineView refresh)
+- Live Activities toggle in Quip iOS Settings: turning OFF should kill any active perms LA + suppress new ones; turning ON should start one if perms are degraded
+
+**Related:** commits `0f3a0be`, `90e8e1a`, `59cfb3a`. PR https://github.com/jboert/Quip/pull/6.
+
+---
+
 ## Completed
 
-*(none yet — move items here as they ship)*
+### 31. iOS terminal URLs aren't tappable
+
+**Status:** ✅ Done — root cause was `.foregroundStyle(.white.opacity(0.85))` on the SwiftUI `Text` overriding the per-run colors set by the `.link` AttributedString runs AND interfering with link-tap recognition. Fix: bake the foreground color into the `AttributedString` itself in `linkifiedTerminalContent` (`attr.foregroundColor = .white.opacity(0.85)`), set link runs to `.cyan` for visual differentiation, and drop the `.foregroundStyle` modifier from the `Text` view.
+
+Diagnosed autonomously via a Node.js fake-iOS-client (`/tmp/quip-content-probe.js`) that auths to the Mac WebSocket, requests terminal content, dumps the raw bytes, and a standalone Swift script (`/tmp/test-linkifier.swift`) that runs the exact `linkifiedTerminalContent` logic against those bytes. That confirmed `raw=6 kept=2` — the linkifier was working correctly all along; the bug was further down the SwiftUI render chain. The earlier "Case B" report was a misread caused by the user testing when no http(s) URLs happened to be in the visible iTerm buffer at that moment.
+
+**Related:** commits `d3bf4c9` (initial linkifier), `b5bb8d7` (scheme filter + tests).

--- a/docs/superpowers/wishlist.md
+++ b/docs/superpowers/wishlist.md
@@ -525,6 +525,42 @@ The 1, 2, 3 quick-action buttons (added in jboert's commit `4e774e6`, tracked un
 
 ---
 
+### 30. Reliability & UX hardening pass (5-thread backlog)
+
+**Status:** Wishlist (brainstorm paused mid-flight on 2026-04-18 — backlogged)
+
+**Context:** Brainstorming session started to explore what would make the app feel more trustworthy. User identified *silent correctness failures* (the app doesn't do what was asked, and nothing tells you it failed) as the #1 pain driver, and picked a weekend-budget appetite. Five threads were surfaced before the session was paused:
+
+**Threads in scope:**
+
+1. **Diagnostic tooling / observability.** CLAUDE.md already lists 7 distinct root causes for a single symptom (photo upload spinning forever). Silent `continue`, silent `try?`, and `guard let ... else { return }` paths cripple triage. The push-notification service just got loud-drop logging (commit `8517835`) as a prototype of the pattern — extend that discipline across the rest of the codebase. Inventory candidate files: `QuipMac/Services/*`, `QuipiOS/Services/*`, `Shared/*`.
+
+2. **Connection truth / status pill honesty.** Commit `3431046` fixed the "pill was lyin'" keepalive-without-pong bug. Next round: surface *why* a disconnect happened, not just the binary. E.g., when the phone flips to "Not connected", it should say whether it was pong timeout, explicit close frame, network loss, or auth failure. Review probe cadence.
+
+3. **State invariants across app lifecycle.** Audit what state persists across `willResignActive` / `didEnterBackground` / `willEnterForeground` / `didBecomeActive` on iOS and the equivalent on Mac. Known offenders: `isPTTActive` isn't reset on `HardwareButtonHandler.stopMonitoring`; Live Activity handles can outlive their activities if user dismisses from Dynamic Island long-press; `PreferencesSyncService.suppressUntil` uses a fixed 2s window that races with network latency; force-quit-after-install is required because `devicectl install` replaces the bundle but doesn't kill the process. Each is a one-line or few-line fix once identified.
+
+4. **Error-handling gaps (silent failures).** Repo-wide audit of `try?`, `if let ... { } else { return }` with no log, empty `catch { }` blocks, and `guard` statements that swallow failures. Triage each: some are legitimately "don't care" (framework quirks), others are real bugs-in-waiting. Convert the real ones to either loud logs or typed errors.
+
+5. **Notification triage in-app (originally bucketed as UX).** Today you have to `tail /tmp/quip-push.log` on the Mac to see why a push didn't fire. Surface recent push attempts + skip reasons in Mac Settings → Notifications. With the weekend budget, a stripped-down version is feasible: a `List` in SettingsView that reads the last N lines from `/tmp/quip-push.log`. Anything fancier (structured events, iOS-side mirror) defers to a later iteration.
+
+**Decisions already made in the paused session:**
+
+- Shape picked: **A** — strategy-level spec covering all 5 threads + their sequencing, with separate implementation plans when each is executed. (B = one thread first, C = monster spec were alternatives.)
+- Top pain: **A = silent correctness failures.**
+- Appetite: **A = weekend / few evenings.** No new shared infrastructure. Ruthless audit + fix the worst offenders only.
+
+**Paused at:** proposing concrete weekend shapes. Three options were on the table when user chose to backlog:
+
+- **A. #1 + #4 together, deep** — observability + silent-error-handling share the same methodology (grep → triage → log or fix). One audit pass yields two threads. #3 gets a short appendix checklist. #2 and #5 defer to a second weekend.
+- **B. Just #1 alone** — tightest single-weekend scope.
+- **C. Shallow sweep across all 5** — one targeted fix per thread, 2-3 hours each. Maximum coverage, surface-level depth, high risk of "looks done but isn't."
+
+**When picking this up:** resume brainstorming from that choice. Recommended starting point is **A** (#1 + #4 together) unless the user's constraints have shifted. If scope creeps beyond a weekend at brainstorming time, consider promoting to a multi-weekend plan with #1+#4 shipped first and the rest queued.
+
+**Related:** commits `8517835` (push-service loud-drop logs as the pattern seed), `843fb68` (volume KVO guard — lifecycle-state example of thread #3), `3431046` (keepalive-pong fix — example of thread #2).
+
+---
+
 ## Completed
 
 *(none yet — move items here as they ship)*

--- a/docs/superpowers/wishlist.md
+++ b/docs/superpowers/wishlist.md
@@ -64,13 +64,21 @@ The iPhone currently cycles through existing Claude Code terminal windows via th
 
 ### 6. Real Claude Code plan mode via Shift+Tab cycling
 
-**Status:** Wishlist (explicitly scrapped from `/plan` v1)
-**Context:** Instead of typing `/plan` as a literal prefix (which only gives *plan-style* behavior via prompt text), actually put Claude Code into its built-in plan mode by pressing Shift+Tab the correct number of times. Requires:
-- Adding `shift_tab` case to `KeystrokeInjector.sendKeystroke` — today's injector supports Return, Ctrl+C, Ctrl+D, Escape, Tab, but not Shift+Tab.
-- Either tracking Claude Code's current mode in Quip locally, OR reading the mode indicator from terminal content (see #7) to know how many Shift+Tab presses to send.
-- A user-visible fallback / manual override when detection fails.
+**Status:** ✅ Done — shipped on `eb-branch` (2026-04-20). Builds on #7's mode detection.
 
-Known risk: without mode detection, blind Shift+Tab presses can land in the wrong mode (Normal / Auto-Accept / Plan cycle is state-dependent).
+**What shipped:**
+- New `shift+tab` case in `KeystrokeInjector.sendKeystroke`. iTerm2 path uses the standard CSI back-tab sequence `ESC [ Z` via `write text ((character id 27) & "[Z") newline no` — concatenating the escape byte with the literal CSI tail in AppleScript. Terminal.app path uses System Events `keystroke "tab" using {shift down}`.
+- Refactored the per-key table from `iTerm2CharIdFor(_) -> Int?` to `iTerm2WriteExpression(for:) -> String?` so it can return multi-character expressions; full table locked under unit tests so accidental edits don't silently break a keystroke.
+- New high-level quick actions on the Mac: `set_plan_mode`, `set_auto_accept_mode`, `set_normal_mode`. Each reads `claudeModeDetector.windowModes[windowId]` and uses `ClaudeMode.shiftTabPresses(from:to:)` to compute exactly the right number of Shift+Tab presses (0…2; cycle is normal → autoAccept → plan → normal). Presses are staggered 80ms apart so Claude Code's TUI redraws between them.
+- Fallback: if the mode for that window is unknown (detector hasn't seen an indicator yet), the Mac broadcasts an `ErrorMessage` toast instead of pressing blind. User then taps the manual `press_shift_tab` action to step the cycle.
+- iOS QuickButton additions: `planMode` ("→Plan mode" with `wand.and.stars` icon, slash category) and `shiftTab` ("Shift+Tab" with `arrow.left.to.line` icon, keystroke category).
+
+**Files:** `QuipMac/Services/KeystrokeInjector.swift` (new shift+tab case + refactored expression table), `Shared/MessageProtocol.swift` (`ClaudeMode.cycle` + `shiftTabPresses(from:to:)` math), `QuipMac/QuipMacApp.swift` (`cycleClaudeMode(to:for:)` helper + 4 new quick-action cases), `QuipiOS/QuipApp.swift` (2 new QuickButton enum cases with display name / label / icon / category / action).
+
+**Tests:** `QuipMac/Tests/KeystrokeInjectorWriteExpressionTests.swift` (locks every key's AppleScript expression under unit tests — single-byte chars + Shift+Tab CSI + case insensitivity + unknown→nil), `Shared/Tests/MessageProtocolTests.swift` (4 new tests for cycle math: no-movement, forward, wrap-around, never-exceeds-cycle-length-minus-one). 116 Mac tests pass; iOS build green.
+
+**Original context** (kept for historical reference):
+Instead of typing `/plan` as a literal prefix (which only gives *plan-style* behavior via prompt text), actually put Claude Code into its built-in plan mode by pressing Shift+Tab the correct number of times. Without mode detection (#7), blind Shift+Tab presses land in the wrong mode (Normal / Auto-Accept / Plan cycle is state-dependent).
 
 ---
 


### PR DESCRIPTION
## Summary

Branch scope has grown beyond the original "Mac TCC perms strip" — now covers three feature lanes plus cleanup. Grouped by lane, newest first:

### URL tray on iPhone (3 commits)
`6599768` · `32fae12` · `d36eb6e`

- Mac: `TerminalURLExtractor` runs `NSDataDetector` over the scraped terminal text, filters by explicit scheme (rejects bare-TLD false positives like `README.md`, `Quip.app`, bare `github.com`; accepts `http(s)://…` and `mailto:` both explicit and bare-email forms). Document order preserved, duplicates stripped.
- iOS: tap-to-open pill strip above the screenshot. 8.5pt monospace capsules, cyan, tap → `UIApplication.shared.open`. Hidden when scrape produces zero URLs.
- Tradeoff made explicit: screenshot path preserved so Claude Code's TUI + ANSI colors stay intact. Inline in-situ URL linkification in the image would require alt-screen capture + ANSI parsing + Python deps — deferred. The tray is the shipping-today compromise.
- Settings → Appearance: "URL tray" toggle (default on), "URL tray limit" stepper (1–50, default 10 most recent).
- Paired test suites (`TerminalURLExtractorTests` Mac · `InlineTerminalContentBranchTests` + `LinkifiedTerminalContentTests` iOS) pin the scheme-filter contract on both sides so they can't drift.

### Real Claude Code plan mode via Shift+Tab
`574e5d1` · `0c2ff54`

- iTerm2 emits CSI back-tab (`ESC [Z`) via `write text ((character id 27) & "[Z") newline no`; Terminal.app uses System Events `keystroke "tab" using {shift down}`.
- Refactored `iTerm2CharIdFor(_) -> Int?` to `iTerm2WriteExpression(for:) -> String?` so multi-char sequences fit.
- Locked the full keystroke table under unit tests so accidental edits don't silently break a keystroke.
- `0c2ff54` added `claudeMode: String?` scraping on the Mac so the phone knows the current mode (normal / plan / autoAccept).

### UITextView rendering + linkifier hardening
`440b175` · `25843f9` · `03ebfc9` · `b5bb8d7`

- `LinkableTerminalText` UIViewRepresentable for reliable tap routing (note: superseded in practice by the image-first branch rule + URL tray — this is now the fallback path when Screen Recording is denied).
- Email addresses linkified as `mailto:`.
- Fixed SwiftUI `.foregroundStyle` stomping on `.link` run colors in `AttributedString`.
- Scheme filter added to the linkifier so bare TLDs (Moldova's `.md`, Google's `.app`) don't become fake links.

### Mac permissions feature (earlier work on the branch)
`59cfb3a` · `90e8e1a` · `0f3a0be` · `8517835`

- Phone sees Mac TCC perms in real time, one-tap opens the right System Settings pane remotely.
- Live Activity surfaces degraded Mac from outside the app.
- SettingsSheet auto-pops on first connect when something's red.
- Quiet Hours gate now covers Live Activities (Dynamic Island was bypassing it).

### Cleanup and housekeeping
`45bd5e6` · `3d36de9` · `75ebd15` · `26f4807` · `1ab8467` · `843fb68` · `8645f85`

- Test bitrot fix (`WindowManagerSessionIdTests` ctor drift).
- Wishlist entries #34 (mac_permissions not reaching iPhone) + #35 (cross-app paste).
- Burn-down housekeeping.
- Backspace CR-phantom fix (iTerm2 `write text` newline default).
- Volume KVO fix (was fighting other apps' volume during app-switcher peek).

## Test plan

- [ ] `xcodebuild test` Mac — 12 `TerminalURLExtractorTests` + existing suites pass
- [ ] `xcodebuild test` iOS — 17 tests across `InlineTerminalContentBranchTests` + `LinkifiedTerminalContentTests` + existing suites pass
- [ ] Real device: URL tray appears with https/http/mailto mix, filter excludes `README.md` / `Quip.app` / bare domains, tap opens Safari, dedupe works, limit stepper clamps pill count
- [ ] Real device: Settings → Appearance toggle hides tray entirely
- [ ] Real device: Shift+Tab cycles Claude Code plan mode (iTerm2 session)
- [ ] Real device: Mac permissions flow still shows real-time status + deep-link to System Settings
- [ ] Real device: Backspace no longer submits partial prompts to Claude Code

🤖 Generated with [Claude Code](https://claude.com/claude-code)