### PR TITLE
Phone layout features + URL tray fix + Settings resize

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,10 @@ QuipiOS/Info.plist
 .build/
 .swiftpm/
 
+# Coverage / profiling artifacts
+*.profraw
+*.profdata
+
 # Machine-local / planning scripts — not for the public repo
 scripts/
 tasks/

--- a/QuipMac/QuipMacApp.swift
+++ b/QuipMac/QuipMacApp.swift
@@ -114,6 +114,7 @@ struct QuipMacApp: App {
                 .environment(pushNotificationService)
                 .environment(whisperStatusStore)
         }
+        .windowResizability(.contentSize)
     }
 
     @State private var servicesStarted = false

--- a/QuipMac/Services/WebSocketServer.swift
+++ b/QuipMac/Services/WebSocketServer.swift
@@ -372,7 +372,9 @@ final class WebSocketServer {
             connectionLog?.record(.authSucceeded, remote: remoteStr, detail: nil)
             onClientAuthenticated?()
         } else {
-            KokoroTTSDebug.log("auth: PIN mismatch (got '\(authMsg.pin)', expected '\(expectedPIN)')")
+            // Never log either PIN — the file is world-readable in /tmp.
+            // Lengths only, so we can still spot a misconfigured client.
+            KokoroTTSDebug.log("auth: PIN mismatch (got len=\(authMsg.pin.count), expected len=\(expectedPIN.count))")
             send(AuthResultMessage(success: false, error: "Incorrect PIN"), to: connection)
             print("[WebSocketServer] Authentication failed: incorrect PIN")
             connectionLog?.record(.authFailed, remote: remoteStr, detail: "incorrect PIN")

--- a/QuipMac/Views/SettingsView.swift
+++ b/QuipMac/Views/SettingsView.swift
@@ -47,7 +47,13 @@ struct SettingsView: View {
                     Label("Notifications", systemImage: "bell.badge")
                 }
         }
-        .frame(width: 520, height: 460)
+        // Vertical resize is the common ask (long tabs like Connection
+        // overflow). Width stays fixed at 520 so content doesn't get spread
+        // out across a stretched gutter. `.top` alignment so extra vertical
+        // space falls below content rather than centering it.
+        .frame(minHeight: 460, idealHeight: 460, maxHeight: .infinity,
+               alignment: .top)
+        .frame(width: 520)
     }
 }
 
@@ -219,8 +225,34 @@ private struct GeneralTab: View {
     /// see it. TimelineView is the cheapest reactive timer in SwiftUI.
     private let permissionProbe = PermissionProbeService()
 
+    private var versionString: String {
+        let info = Bundle.main.infoDictionary
+        let short = info?["CFBundleShortVersionString"] as? String ?? "?"
+        let build = info?["CFBundleVersion"] as? String ?? "?"
+        return "\(short) (\(build)) — built \(buildTimestamp)"
+    }
+
+    /// Mtime of the compiled binary. Bumps every rebuild without needing
+    /// a project-level version bump — useful for "did my reinstall land".
+    private var buildTimestamp: String {
+        guard let path = Bundle.main.executablePath,
+              let attrs = try? FileManager.default.attributesOfItem(atPath: path),
+              let date = attrs[.modificationDate] as? Date else { return "?" }
+        let f = DateFormatter()
+        f.dateFormat = "yyyy-MM-dd HH:mm"
+        return f.string(from: date)
+    }
+
     var body: some View {
         Form {
+            Section("About") {
+                LabeledContent("Version") {
+                    Text(versionString)
+                        .font(.system(.body, design: .monospaced))
+                        .textSelection(.enabled)
+                }
+            }
+
             Section("Permissions") {
                 TimelineView(.periodic(from: .now, by: 3.0)) { _ in
                     let perms = permissionProbe.probe()

--- a/QuipiOS/QuipApp.swift
+++ b/QuipiOS/QuipApp.swift
@@ -366,7 +366,13 @@ struct QuipApp: App {
                 if let screenshot, !screenshot.isEmpty {
                     terminalContentScreenshot = screenshot
                 }
-                terminalContentURLs = urls
+                // Same preservation rule as screenshot: Mac sends urls=nil when
+                // extraction returns empty (transient iTerm scrape miss, brief
+                // window blur, throttle gap). Don't wipe a good tray on a bad
+                // refresh — selectedWindowId.onChange clears on real switches.
+                if let urls, !urls.isEmpty {
+                    terminalContentURLs = urls
+                }
             }
         }
 

--- a/QuipiOS/QuipApp.swift
+++ b/QuipiOS/QuipApp.swift
@@ -246,6 +246,12 @@ struct QuipApp: App {
                 monitorName = update.monitor
                 if let a = update.screenAspect, a > 0 { screenAspect = a }
                 volumeHandler.startMonitoring(windowCount: update.windows.count)
+                // Auto-arrange (FR-2) — fire on every list change unless the
+                // user has explicitly taken control via cycle button or drag.
+                // Auto-arrange chooser fires from MainiOSView via
+                // `.onChange(of: windows)` since the relevant @AppStorage
+                // and `phoneFrameOverrides` state lives there. We just
+                // refresh the windows binding here and the View reacts.
                 // Allow all orientations once we have windows, suggest landscape
                 if wasEmpty && !update.windows.isEmpty {
                     AppOrientationDelegate.allowAllOrientations = true
@@ -632,6 +638,16 @@ struct MainiOSView: View {
     // command, the Y/N confirmations that Claude asks for, Esc to dismiss,
     // and Ctrl+C to abort. Everything else is opt-in from Settings.
     @AppStorage("enabledQuickButtons") private var enabledQuickButtonsRaw: String = "plan,yes,no,esc,ctrlC"
+    // Per-button toggles for the main control row (chevrons, spawn, arrange,
+    // photo, keyboard, return). PTT mic and the row itself stay mandatory.
+    // Default ON — existing users keep their current button set.
+    @AppStorage("mainRow.cycleLeft") private var mainRowCycleLeft: Bool = true
+    @AppStorage("mainRow.cycleRight") private var mainRowCycleRight: Bool = true
+    @AppStorage("mainRow.spawn") private var mainRowSpawn: Bool = true
+    @AppStorage("mainRow.arrange") private var mainRowArrange: Bool = true
+    @AppStorage("mainRow.photo") private var mainRowPhoto: Bool = true
+    @AppStorage("mainRow.keyboard") private var mainRowKeyboard: Bool = true
+    @AppStorage("mainRow.return") private var mainRowReturn: Bool = true
     @State private var showSettings = false
     @State private var showQRScanner = false
     @State private var showSpawnPicker = false
@@ -648,11 +664,42 @@ struct MainiOSView: View {
     @State private var testResultAutoDismiss: Task<Void, Never>?
     /// Which layout the next tap on the arrange button will send. The icon
     /// shown on the button reflects this so the user can predict the outcome.
-    /// Phone-only display layout for window rectangles. `nil` = show whatever
-    /// layout the Mac reports; `"horizontal"` = columns side-by-side on the
+    /// Phone-only display layout for window rectangles. `""` = show whatever
+    /// the auto-chooser picks (or Mac's frames if both this and per-window
+    /// overrides are empty); `"horizontal"` = columns side-by-side on the
     /// phone; `"vertical"` = rows top-to-bottom. **Does not** touch the
     /// Mac's actual window positions — just reorganizes the preview here.
-    @State private var phoneLayoutOverride: String? = nil
+    /// Persisted across launches; @AppStorage so a returning user keeps
+    /// their last mode without a flash of unstyled layout on cold launch.
+    @AppStorage("phoneLayoutOverride") private var phoneLayoutOverrideRaw: String = ""
+    /// True once the user has explicitly cycled the arrange button or
+    /// dragged a window — auto-chooser stops firing on subsequent
+    /// windows-list arrivals so we don't fight the user's choice.
+    /// Realign button (US-002) clears this flag back to false.
+    @AppStorage("phoneLayoutManualSticky") private var manualLayoutSticky: Bool = false
+    /// Per-window manual position overrides written by drag-to-move (US-005).
+    /// JSON-encoded `[String: WindowFrame]` keyed by `windowId`. Lookup wins
+    /// over auto-arrange in `phoneLayoutFrame`. Pruned on every windows-list
+    /// arrival so closed windows don't leak entries.
+    @AppStorage("phoneFrameOverridesJSON") private var phoneFrameOverridesJSON: String = "{}"
+    /// In-memory cache of decoded overrides — rebuilt from JSON on appear,
+    /// written back to JSON on every mutation. Avoids a JSON round-trip per
+    /// `phoneLayoutFrame` call inside the layout `ForEach`.
+    @State private var phoneFrameOverrides: [String: WindowFrame] = [:]
+    /// Active drag state: which window is being dragged + accumulated
+    /// translation. Nil when no drag is in flight.
+    @State private var draggingWindowId: String? = nil
+    @State private var dragTranslation: CGSize = .zero
+    /// Last device-detected windows count + orientation snapshot used to
+    /// short-circuit the chooser when nothing relevant changed.
+    @State private var lastChooserCount: Int = -1
+
+    /// Computed view of the persisted raw string. `""` ↔ nil so callers
+    /// can keep working in the "no override" mental model without seeing
+    /// the @AppStorage encoding artifact.
+    private var phoneLayoutOverride: String? {
+        phoneLayoutOverrideRaw.isEmpty ? nil : phoneLayoutOverrideRaw
+    }
     // When true, the window-picker layout card collapses and InlineTerminalContent
     // expands to fill its space — gives the terminal more vertical room for reading.
     @State private var isTerminalExpanded = false
@@ -806,6 +853,27 @@ struct MainiOSView: View {
         .environment(\.quipColors, colors)
         .onAppear {
             updateOrientation()
+            // Restore persisted phone-side window overrides so a returning
+            // user sees their drag layout before the first windows-list
+            // arrives. No-op on first launch (empty JSON → empty dict).
+            loadOverrides()
+            // Initial chooser pass for the case where windows already
+            // populated before this view appeared (rare but possible on
+            // reconnect). Real subsequent fires happen via .onChange below.
+            if !windows.isEmpty {
+                pruneOverrides(activeWindowIds: Set(windows.map(\.id)))
+                runAutoChooser(count: windows.count)
+            }
+        }
+        .onChange(of: windows) { _, newValue in
+            // FR-2 + FR-8: every windows-list change re-fires the chooser
+            // (skipped when manualLayoutSticky is set) and prunes stale
+            // override entries for closed windows.
+            pruneOverrides(activeWindowIds: Set(newValue.map(\.id)))
+            runAutoChooser(count: newValue.count)
+        }
+        .onAppear {
+            // Companion onAppear for the rest of the legacy hookup below.
             // Register image upload result callbacks. These are idempotent
             // reassignments so re-firing onAppear is harmless.
             client.onImageUploadAck = { [weak pendingImage] _ in
@@ -1475,46 +1543,67 @@ struct MainiOSView: View {
             // Pending image thumbnail — only takes space when an image is attached.
             PendingImagePreviewStrip(state: pendingImage)
 
+            // Cluster gating — small gap (10pt) appears between adjacent
+            // clusters when both have visible buttons. PTT mic is always
+            // visible and stays geometrically centered via flexible
+            // Spacers on each side. Adding/removing buttons recenters
+            // automatically because the Spacers absorb the slack.
+            let leftNavOn = mainRowCycleLeft || mainRowCycleRight
+            let leftMgmtOn = mainRowSpawn || mainRowArrange
+            let rightSendOn = mainRowKeyboard || mainRowReturn
+
             // Control buttons
-            HStack(spacing: 6) {
-                // Previous window — slimmer than the main input buttons so
-                // the PTT/keyboard/Return trio visually dominates the row.
-                Button {
-                    cycleWindow(direction: -1)
-                } label: {
-                    Image(systemName: "chevron.left")
-                        .font(.system(size: 13, weight: .semibold))
-                        .foregroundStyle(windows.count > 1 ? colors.textPrimary : colors.textFaint)
-                        .frame(width: navW, height: navH)
-                        .background(colors.surface)
-                        .clipShape(RoundedRectangle(cornerRadius: 10))
+            HStack(spacing: 0) {
+                // LEFT cluster 1: window nav (chevrons)
+                HStack(spacing: 6) {
+                    if mainRowCycleLeft {
+                        Button {
+                            cycleWindow(direction: -1)
+                        } label: {
+                            Image(systemName: "chevron.left")
+                                .font(.system(size: 13, weight: .semibold))
+                                .foregroundStyle(windows.count > 1 ? colors.textPrimary : colors.textFaint)
+                                .frame(width: navW, height: navH)
+                                .background(colors.surface)
+                                .clipShape(RoundedRectangle(cornerRadius: 10))
+                        }
+                        .disabled(windows.count <= 1)
+                    }
+                    if mainRowCycleRight {
+                        Button {
+                            cycleWindow(direction: 1)
+                        } label: {
+                            Image(systemName: "chevron.right")
+                                .font(.system(size: 13, weight: .semibold))
+                                .foregroundStyle(windows.count > 1 ? colors.textPrimary : colors.textFaint)
+                                .frame(width: navW, height: navH)
+                                .background(colors.surface)
+                                .clipShape(RoundedRectangle(cornerRadius: 10))
+                        }
+                        .disabled(windows.count <= 1)
+                    }
                 }
-                .disabled(windows.count <= 1)
 
-                // Next window
-                Button {
-                    cycleWindow(direction: 1)
-                } label: {
-                    Image(systemName: "chevron.right")
-                        .font(.system(size: 13, weight: .semibold))
-                        .foregroundStyle(windows.count > 1 ? colors.textPrimary : colors.textFaint)
-                        .frame(width: navW, height: navH)
-                        .background(colors.surface)
-                        .clipShape(RoundedRectangle(cornerRadius: 10))
+                // Visual gap between nav cluster and window-mgmt cluster.
+                // Only present when both clusters have at least one button.
+                if leftNavOn && leftMgmtOn {
+                    Spacer().frame(width: 10)
                 }
-                .disabled(windows.count <= 1)
 
-                // Spawn new window from project directory
-                Button {
-                    showSpawnPicker = true
-                } label: {
-                    Image(systemName: "plus")
-                        .font(.system(size: 16, weight: .semibold))
-                        .foregroundStyle(colors.textPrimary)
-                        .frame(width: auxW, height: auxH)
-                        .background(colors.surface)
-                        .clipShape(RoundedRectangle(cornerRadius: 12))
-                }
+                // LEFT cluster 2: window mgmt (spawn, arrange)
+                HStack(spacing: 6) {
+                    if mainRowSpawn {
+                        Button {
+                            showSpawnPicker = true
+                        } label: {
+                            Image(systemName: "plus")
+                                .font(.system(size: 16, weight: .semibold))
+                                .foregroundStyle(colors.textPrimary)
+                                .frame(width: auxW, height: auxH)
+                                .background(colors.surface)
+                                .clipShape(RoundedRectangle(cornerRadius: 12))
+                        }
+                    }
 
                 // Arrange — phone-only display toggle. Cycles through
                 // Mac-layout (default, shows real Mac positions), columns
@@ -1522,37 +1611,51 @@ struct MainiOSView: View {
                 // NOT move windows on the Mac; just reorganizes the preview
                 // here so overlapping/off-screen windows become distinct
                 // cards when you need 'em.
-                Button {
-                    switch phoneLayoutOverride {
-                    case nil: phoneLayoutOverride = "horizontal"
-                    case "horizontal": phoneLayoutOverride = "vertical"
-                    default: phoneLayoutOverride = nil
-                    }
-                    UIImpactFeedbackGenerator(style: .light).impactOccurred()
-                } label: {
-                    let icon: String = {
+                // Single button — tap cycles horizontal/vertical, long-press
+                // realigns (clears manual drag overrides + re-fires the
+                // auto-chooser). Combined into one slot per `feedback_compact_ui`
+                // so the row doesn't overflow. nil isn't a tap-cycle step
+                // anymore; the auto-chooser owns "no override" now.
+                if mainRowArrange {
+                    Button {
                         switch phoneLayoutOverride {
-                        case "horizontal": return "rectangle.split.3x1"
-                        case "vertical": return "rectangle.split.1x3"
-                        default: return "rectangle.3.group"
+                        case "horizontal": phoneLayoutOverrideRaw = "vertical"
+                        default: phoneLayoutOverrideRaw = "horizontal"
                         }
-                    }()
-                    Image(systemName: icon)
-                        .font(.system(size: 16, weight: .semibold))
-                        .foregroundStyle(windows.count >= 2 ? colors.textPrimary : colors.textFaint)
-                        .frame(width: auxW, height: auxH)
-                        .background(colors.surface)
-                        .clipShape(RoundedRectangle(cornerRadius: 12))
+                        manualLayoutSticky = true
+                        UIImpactFeedbackGenerator(style: .light).impactOccurred()
+                    } label: {
+                        let icon: String = {
+                            switch phoneLayoutOverride {
+                            case "horizontal": return "rectangle.split.3x1"
+                            case "vertical": return "rectangle.split.1x3"
+                            default: return "rectangle.3.group"
+                            }
+                        }()
+                        Image(systemName: icon)
+                            .font(.system(size: 16, weight: .semibold))
+                            .foregroundStyle(windows.count >= 2 ? colors.textPrimary : colors.textFaint)
+                            .frame(width: auxW, height: auxH)
+                            .background(colors.surface)
+                            .clipShape(RoundedRectangle(cornerRadius: 12))
+                    }
+                    .disabled(windows.filter(\.enabled).count < 2)
+                    .simultaneousGesture(
+                        LongPressGesture(minimumDuration: 0.5).onEnded { _ in
+                            realignWindows()
+                            UIImpactFeedbackGenerator(style: .medium).impactOccurred()
+                        }
+                    )
                 }
-                .disabled(windows.filter(\.enabled).count < 2)
+                } // close LEFT cluster 2 HStack
+
+                // Big flexible spacer pinning mic to geometric center.
+                Spacer(minLength: 12)
 
                 // Push to talk — icon-only. Red mic when idle; when live, the
                 // pill keeps its surface fill but gains a red stroke so it
                 // reads as "recording" without scorching the eyeballs with a
                 // solid-red rectangle. Icon switches to a red stop square.
-                // Symmetric spacers pin the mic to geometric center of the
-                // row regardless of how many buttons sit on either side.
-                Spacer()
                 Button {
                     if isRecording {
                         onStopRecording()
@@ -1571,60 +1674,65 @@ struct MainiOSView: View {
                                 .strokeBorder(Color.red.opacity(0.7), lineWidth: isRecording ? 2 : 0)
                         )
                 }
-                Spacer()
+                Spacer(minLength: 12)
 
-                // Attach image — sits adjacent to the PTT mic since both are
-                // primary input actions (drop in media vs. speak). Tapping
-                // opens source picker (library / camera).
-                Button {
-                    showingImageSourceSheet = true
-                } label: {
-                    Image(systemName: pendingImage.hasPendingImage ? "photo.fill" : "photo")
-                        .font(.system(size: 20, weight: .medium))
-                        .foregroundStyle(pendingImage.hasPendingImage ? colors.buttonPrimary : colors.textPrimary)
-                        .frame(width: btnW, height: btnH)
-                        .background(colors.surface)
-                        .clipShape(RoundedRectangle(cornerRadius: 12))
-                }
-                .accessibilityLabel("Attach image")
-
-                // Type — toggles the text input bar above the terminal
-                // content. Sized down to the secondary tier (matches `+`
-                // and Arrange) since it's a mode toggle, not a send action.
-                Button {
-                    withAnimation(.easeInOut(duration: 0.2)) {
-                        showTextInput.toggle()
-                        if !showTextInput { textInputValue = "" }
+                // RIGHT cluster 1: photo (input attach)
+                HStack(spacing: 6) {
+                    if mainRowPhoto {
+                        Button {
+                            showingImageSourceSheet = true
+                        } label: {
+                            Image(systemName: pendingImage.hasPendingImage ? "photo.fill" : "photo")
+                                .font(.system(size: 20, weight: .medium))
+                                .foregroundStyle(pendingImage.hasPendingImage ? colors.buttonPrimary : colors.textPrimary)
+                                .frame(width: btnW, height: btnH)
+                                .background(colors.surface)
+                                .clipShape(RoundedRectangle(cornerRadius: 12))
+                        }
+                        .accessibilityLabel("Attach image")
                     }
-                } label: {
-                    Image(systemName: showTextInput ? "keyboard.chevron.compact.down" : "keyboard")
-                        .font(.system(size: 16, weight: .medium))
-                        .foregroundStyle(colors.textPrimary)
-                        .frame(width: auxW, height: auxH)
-                        .background(colors.surface)
-                        .clipShape(RoundedRectangle(cornerRadius: 12))
                 }
 
-                // Press Return — flushes any pending image first AND defers the
-                // press_return until the image has actually been dispatched, so
-                // the Mac receives them in the correct order (path first, then
-                // Enter) rather than racing and pressing Enter before the path
-                // types.
-                Button {
-                    if let wid = selectedWindowId {
-                        sendPendingImageIfNeeded(windowId: wid) {
-                            client.send(QuickActionMessage(windowId: wid, action: "press_return"))
+                // Visual gap between photo and send-cluster (keyboard/return).
+                if mainRowPhoto && rightSendOn {
+                    Spacer().frame(width: 10)
+                }
+
+                // RIGHT cluster 2: send (keyboard, return)
+                HStack(spacing: 6) {
+                    if mainRowKeyboard {
+                        Button {
+                            withAnimation(.easeInOut(duration: 0.2)) {
+                                showTextInput.toggle()
+                                if !showTextInput { textInputValue = "" }
+                            }
+                        } label: {
+                            Image(systemName: showTextInput ? "keyboard.chevron.compact.down" : "keyboard")
+                                .font(.system(size: 16, weight: .medium))
+                                .foregroundStyle(colors.textPrimary)
+                                .frame(width: auxW, height: auxH)
+                                .background(colors.surface)
+                                .clipShape(RoundedRectangle(cornerRadius: 12))
                         }
                     }
-                } label: {
-                    Image(systemName: "return")
-                        .font(.system(size: 20, weight: .medium))
-                        .foregroundStyle(selectedWindowId != nil ? colors.textPrimary : colors.textFaint)
-                        .frame(width: btnW, height: btnH)
-                        .background(colors.surface)
-                        .clipShape(RoundedRectangle(cornerRadius: 12))
+                    if mainRowReturn {
+                        Button {
+                            if let wid = selectedWindowId {
+                                sendPendingImageIfNeeded(windowId: wid) {
+                                    client.send(QuickActionMessage(windowId: wid, action: "press_return"))
+                                }
+                            }
+                        } label: {
+                            Image(systemName: "return")
+                                .font(.system(size: 20, weight: .medium))
+                                .foregroundStyle(selectedWindowId != nil ? colors.textPrimary : colors.textFaint)
+                                .frame(width: btnW, height: btnH)
+                                .background(colors.surface)
+                                .clipShape(RoundedRectangle(cornerRadius: 12))
+                        }
+                        .disabled(selectedWindowId == nil)
+                    }
                 }
-                .disabled(selectedWindowId == nil)
 
                 // In landscape, fold the quick-button row INTO this main row
                 // — saves a whole row of vertical space and keeps everything
@@ -2036,6 +2144,20 @@ struct MainiOSView: View {
                         ForEach(Array(windows.enumerated()), id: \.element.id) { index, window in
                             let effectiveFrame = phoneLayoutFrame(for: window, index: index, total: windows.count) ?? window.frame
                             let rect = windowRect(frame: effectiveFrame, in: mac.size, inset: 3)
+                            let isDragging = draggingWindowId == window.id
+
+                            // Ghost — faint placeholder at the original
+                            // position so the user can see where the card
+                            // came from while dragging it elsewhere.
+                            if isDragging {
+                                RoundedRectangle(cornerRadius: 12)
+                                    .strokeBorder(Color(hex: window.color).opacity(0.3),
+                                                  style: StrokeStyle(lineWidth: 1, dash: [4, 4]))
+                                    .frame(width: rect.width, height: rect.height)
+                                    .position(x: rect.midX, y: rect.midY)
+                                    .allowsHitTesting(false)
+                            }
+
                             WindowRectangle(
                                 window: window,
                                 isSelected: window.id == selectedWindowId,
@@ -2058,7 +2180,11 @@ struct MainiOSView: View {
                                 }
                             )
                             .frame(width: rect.width, height: rect.height)
+                            .scaleEffect(isDragging ? 1.05 : 1.0)
+                            .shadow(color: .black.opacity(isDragging ? 0.35 : 0),
+                                    radius: isDragging ? 8 : 0, y: isDragging ? 4 : 0)
                             .position(x: rect.midX, y: rect.midY)
+                            .offset(isDragging ? dragTranslation : .zero)
                             // Pulsing yellow dot overlay when this window's
                             // waiting for user input. Drawn in the top-right
                             // of the rect so it doesn't cover the window
@@ -2072,7 +2198,37 @@ struct MainiOSView: View {
                                         .offset(x: -4, y: 4)
                                 }
                             }
-                            .zIndex(attentionCenter.windowsNeedingAttention.contains(window.id) ? 10 : 0)
+                            // Active drag floats above neighbors; otherwise
+                            // attention dot wins (existing behavior).
+                            .zIndex(isDragging ? 100
+                                    : attentionCenter.windowsNeedingAttention.contains(window.id) ? 10 : 0)
+                            // Drag-to-move (US-005). minimumDistance keeps
+                            // single taps reaching `onSelect` — only sustained
+                            // 10pt+ travel activates the drag.
+                            .gesture(
+                                DragGesture(minimumDistance: 10)
+                                    .onChanged { value in
+                                        if draggingWindowId != window.id {
+                                            draggingWindowId = window.id
+                                            UIImpactFeedbackGenerator(style: .soft).impactOccurred()
+                                        }
+                                        dragTranslation = value.translation
+                                    }
+                                    .onEnded { value in
+                                        let inset: CGFloat = 3
+                                        let usableW = mac.size.width - inset * 2
+                                        let usableH = mac.size.height - inset * 2
+                                        let droppedX = (rect.midX + value.translation.width - inset) / usableW
+                                        let droppedY = (rect.midY + value.translation.height - inset) / usableH
+                                        let dropCenter = CGPoint(
+                                            x: max(0, min(1, droppedX)),
+                                            y: max(0, min(1, droppedY))
+                                        )
+                                        handleDrop(windowId: window.id, dropCenter: dropCenter)
+                                        draggingWindowId = nil
+                                        dragTranslation = .zero
+                                    }
+                            )
                         }
                     }
                 }
@@ -2098,12 +2254,22 @@ struct MainiOSView: View {
         }
     }
 
-    /// Phone-only override frame when the user has toggled the arrange
-    /// button — lays out windows as clean columns or rows on the phone
-    /// preview without touching the Mac. Returns `nil` when the Mac's real
-    /// layout should be used.
+    /// Phone-only override frame for a window. Priority:
+    ///   1. Per-window manual drag override (FR-16) — wins over everything.
+    ///   2. Auto-arrange mode (`phoneLayoutOverride` set by chooser or
+    ///      cycle button) — clean grid laid out via `gridFrame`.
+    ///   3. `nil` → caller falls back to the Mac's real frame.
     private func phoneLayoutFrame(for window: WindowState, index: Int, total: Int) -> WindowFrame? {
+        if let manual = phoneFrameOverrides[window.id] { return manual }
         guard let mode = phoneLayoutOverride, total > 0 else { return nil }
+        return Self.gridFrame(mode: mode, index: index, total: total)
+    }
+
+    /// Grid cell for a given mode + position. Pure fn for unit tests
+    /// (PhoneLayoutChooserTests). Returns `nil` for unknown modes so callers
+    /// can fall through to the Mac frame.
+    static func gridFrame(mode: String, index: Int, total: Int) -> WindowFrame? {
+        guard total > 0, index >= 0, index < total else { return nil }
         switch mode {
         case "horizontal":
             let w = 1.0 / Double(total)
@@ -2114,6 +2280,133 @@ struct MainiOSView: View {
         default:
             return nil
         }
+    }
+
+    /// Auto-arrange chooser. Pure fn — picks `"horizontal"` for ≤2 windows,
+    /// `"vertical"` for ≥3. Heuristic is documented in the PRD §9.1 and
+    /// expected to evolve based on device testing.
+    static func chooseAutoLayout(count: Int) -> String {
+        count <= 2 ? "horizontal" : "vertical"
+    }
+
+    /// Re-fire the auto-chooser given the current windows count. Called from
+    /// `onLayoutUpdate` and from the Realign button. Skips when the user has
+    /// engaged the manual-sticky flag UNLESS `force` is true (Realign path).
+    private func runAutoChooser(count: Int, force: Bool = false) {
+        guard count > 0 else { return }
+        if !force && manualLayoutSticky { return }
+        // Don't re-pick if neither the count nor the mode would change —
+        // avoids needless @AppStorage writes on every windows-list arrival.
+        if !force && count == lastChooserCount { return }
+        let pick = Self.chooseAutoLayout(count: count)
+        if phoneLayoutOverrideRaw != pick {
+            phoneLayoutOverrideRaw = pick
+        }
+        lastChooserCount = count
+    }
+
+    /// Realign button action — wipes manual drag overrides, clears the
+    /// sticky flag so the chooser is allowed to fire again, and re-runs
+    /// the chooser immediately so the user sees the auto layout right away.
+    private func realignWindows() {
+        withAnimation(.spring(response: 0.25, dampingFraction: 0.8)) {
+            phoneFrameOverrides = [:]
+            persistOverrides()
+            manualLayoutSticky = false
+            lastChooserCount = -1
+            runAutoChooser(count: windows.count, force: true)
+        }
+    }
+
+    /// Re-encode `phoneFrameOverrides` into JSON and write to @AppStorage.
+    /// Called after every mutation so a force-quit doesn't lose drag work.
+    private func persistOverrides() {
+        if let data = try? JSONEncoder().encode(phoneFrameOverrides),
+           let json = String(data: data, encoding: .utf8) {
+            phoneFrameOverridesJSON = json
+        }
+    }
+
+    /// Decode the persisted override JSON into the in-memory dictionary.
+    /// Called on view appear so a returning user sees their last positions
+    /// before the first windows-list arrives — no flash of unstyled layout.
+    private func loadOverrides() {
+        guard let data = phoneFrameOverridesJSON.data(using: .utf8),
+              let decoded = try? JSONDecoder().decode([String: WindowFrame].self, from: data)
+        else { return }
+        phoneFrameOverrides = decoded
+    }
+
+    /// Drop closed windows from the override dictionary so it doesn't grow
+    /// forever. Called from `onLayoutUpdate` whenever the list arrives.
+    private func pruneOverrides(activeWindowIds: Set<String>) {
+        let filtered = phoneFrameOverrides.filter { activeWindowIds.contains($0.key) }
+        if filtered.count != phoneFrameOverrides.count {
+            phoneFrameOverrides = filtered
+            persistOverrides()
+        }
+    }
+
+    /// Drag-end handler. `dropCenter` is the dropped card's center in
+    /// normalized 0–1 coordinates within the host-screen rect. Decides
+    /// between swap-on-overlap (FR-15) and snap-to-grid (FR-14), writes
+    /// the result to `phoneFrameOverrides`, and flips the user out of
+    /// auto-arrange so the manual frame actually takes effect (FR-13).
+    private func handleDrop(windowId: String, dropCenter: CGPoint) {
+        let total = windows.count
+        guard total > 0,
+              let droppedIdx = windows.firstIndex(where: { $0.id == windowId }) else { return }
+
+        // Find a candidate swap target: any other window whose effective
+        // center is within 0.05 of dropped center (~30pt on a typical phone
+        // host-screen rect of 600pt wide).
+        let swapThreshold: CGFloat = 0.05
+        let target = windows.enumerated().first { (idx, w) -> Bool in
+            guard w.id != windowId else { return false }
+            let frame = phoneLayoutFrame(for: w, index: idx, total: total) ?? w.frame
+            let cx = frame.x + frame.width / 2
+            let cy = frame.y + frame.height / 2
+            let dx = CGFloat(cx) - dropCenter.x
+            let dy = CGFloat(cy) - dropCenter.y
+            return abs(dx) < swapThreshold && abs(dy) < swapThreshold
+        }
+
+        withAnimation(.spring(response: 0.25, dampingFraction: 0.75)) {
+            if let (targetIdx, targetWin) = target {
+                // Swap: both windows' effective frames trade places.
+                let droppedFrame = phoneLayoutFrame(for: windows[droppedIdx], index: droppedIdx, total: total) ?? windows[droppedIdx].frame
+                let targetFrame = phoneLayoutFrame(for: targetWin, index: targetIdx, total: total) ?? targetWin.frame
+                phoneFrameOverrides[windowId] = targetFrame
+                phoneFrameOverrides[targetWin.id] = droppedFrame
+            } else {
+                // Snap-to-grid: pick the auto-mode's nearest cell.
+                let mode = phoneLayoutOverride ?? Self.chooseAutoLayout(count: total)
+                let nearestIdx = Self.nearestGridIndex(mode: mode, total: total, dropCenter: dropCenter)
+                if let cell = Self.gridFrame(mode: mode, index: nearestIdx, total: total) {
+                    phoneFrameOverrides[windowId] = cell
+                }
+            }
+            // First completed drag of a session disengages auto-arrange so
+            // the manual frame actually wins. Subsequent drags don't need to
+            // re-set the flag (idempotent).
+            manualLayoutSticky = true
+            persistOverrides()
+        }
+    }
+
+    /// Pure-fn nearest-cell finder for snap-to-grid. Returns the index whose
+    /// `gridFrame` center is closest to `dropCenter` in normalized space.
+    static func nearestGridIndex(mode: String, total: Int, dropCenter: CGPoint) -> Int {
+        var bestIdx = 0
+        var bestDist = CGFloat.greatestFiniteMagnitude
+        for i in 0..<total {
+            guard let cell = gridFrame(mode: mode, index: i, total: total) else { continue }
+            let cx = CGFloat(cell.x + cell.width / 2)
+            let cy = CGFloat(cell.y + cell.height / 2)
+            let d = hypot(cx - dropCenter.x, cy - dropCenter.y)
+            if d < bestDist { bestDist = d; bestIdx = i }
+        }
+        return bestIdx
     }
 
     private func windowRect(frame: WindowFrame, in size: CGSize, inset: CGFloat) -> CGRect {
@@ -3266,6 +3559,11 @@ struct SettingsSheet: View {
                                 .foregroundStyle(.secondary)
                         }
                     }
+                    NavigationLink {
+                        MainRowButtonsSheet()
+                    } label: {
+                        Text("Main Row Buttons")
+                    }
                 }
             }
             .listStyle(.insetGrouped)
@@ -3398,6 +3696,39 @@ struct SettingsSheet: View {
 /// instead of inlining the ~18-chip grid on the main Settings page. Keeps the
 /// top-level Settings list scannable without losing the density the chip grid
 /// provides here.
+/// Settings sheet for toggling each button in the main control row.
+/// PTT mic stays mandatory (core function); everything else can be hidden
+/// to keep the row from overflowing on smaller phones or to reduce
+/// per-thumb visual noise. @AppStorage-backed so toggles persist.
+struct MainRowButtonsSheet: View {
+    @AppStorage("mainRow.cycleLeft") private var cycleLeft: Bool = true
+    @AppStorage("mainRow.cycleRight") private var cycleRight: Bool = true
+    @AppStorage("mainRow.spawn") private var spawn: Bool = true
+    @AppStorage("mainRow.arrange") private var arrange: Bool = true
+    @AppStorage("mainRow.photo") private var photo: Bool = true
+    @AppStorage("mainRow.keyboard") private var keyboard: Bool = true
+    @AppStorage("mainRow.return") private var pressReturn: Bool = true
+
+    var body: some View {
+        List {
+            Section {
+                Toggle(isOn: $cycleLeft) { Label("Previous Window", systemImage: "chevron.left") }
+                Toggle(isOn: $cycleRight) { Label("Next Window", systemImage: "chevron.right") }
+                Toggle(isOn: $spawn) { Label("Spawn New Window", systemImage: "plus") }
+                Toggle(isOn: $arrange) { Label("Arrange Layout", systemImage: "rectangle.3.group") }
+                Toggle(isOn: $photo) { Label("Attach Image", systemImage: "photo") }
+                Toggle(isOn: $keyboard) { Label("Keyboard Toggle", systemImage: "keyboard") }
+                Toggle(isOn: $pressReturn) { Label("Press Return", systemImage: "return") }
+            } footer: {
+                Text("PTT mic always shows. Hide buttons you don't use to keep the row uncluttered. Long-press the Arrange button to realign auto-layout.")
+            }
+        }
+        .listStyle(.insetGrouped)
+        .navigationTitle("Main Row Buttons")
+        .navigationBarTitleDisplayMode(.inline)
+    }
+}
+
 struct QuickButtonsSheet: View {
     @Binding var enabledQuickButtonsRaw: String
 

--- a/QuipiOS/QuipApp.swift
+++ b/QuipiOS/QuipApp.swift
@@ -3005,6 +3005,22 @@ func linkifiedTerminalContent(_ raw: String) -> AttributedString {
     return attr
 }
 
+/// User preference for how window content renders. `.auto` keeps the
+/// historic image > text > loading priority; `.image` and `.text` are
+/// hard overrides that stop the panel flickering between modes when the
+/// Mac's screenshot stream is unstable.
+enum ContentRenderMode: String, CaseIterable, Identifiable {
+    case auto, image, text
+    var id: String { rawValue }
+    var label: String {
+        switch self {
+        case .auto: return "Auto"
+        case .image: return "Image"
+        case .text: return "Text"
+        }
+    }
+}
+
 struct InlineTerminalContent: View {
     let content: String
     let screenshot: String?
@@ -3034,6 +3050,15 @@ struct InlineTerminalContent: View {
     /// user's pick survives relaunch, and shared between portrait and
     /// landscape views so cycling in one affects both.
     @AppStorage("contentZoomLevel") private var contentZoomLevel = 1
+    /// `auto` (default) preserves the image > text > loading priority and
+    /// last-good-screenshot caching. `image` and `text` are hard overrides
+    /// that lock the renderer to one branch — useful when the Mac screenshot
+    /// stream is intermittently empty and the auto path keeps bouncing
+    /// between image and text. Stored as the enum's rawValue.
+    @AppStorage("contentRenderMode") private var contentRenderModeRaw: String = ContentRenderMode.auto.rawValue
+    private var contentRenderMode: ContentRenderMode {
+        ContentRenderMode(rawValue: contentRenderModeRaw) ?? .auto
+    }
     private let refreshTimer = Timer.publish(every: 2, on: .main, in: .common).autoconnect()
 
     /// Live horizontal offset applied to the content panel while a
@@ -3055,26 +3080,52 @@ struct InlineTerminalContent: View {
     /// flip the priority again.
     enum RenderBranch { case image, text, loading }
 
-    /// Priority: image > text > loading. Image is the normal state and
-    /// the one the state layer works hard to preserve (last-good screenshot
-    /// caching so network blips don't kick us out). Text is the acceptable
-    /// fallback when no screenshot has ever been received — user's stated
-    /// preference is "plain text beats an empty Loading screen." Loading
-    /// is the truly-no-content state (first connect, between window switches).
+    /// Priority for `.auto`: image > text > loading. Image is the normal
+    /// state and the one the state layer works hard to preserve (last-good
+    /// screenshot caching so network blips don't kick us out). Text is the
+    /// acceptable fallback when no screenshot has ever been received — user's
+    /// stated preference is "plain text beats an empty Loading screen."
+    /// Loading is the truly-no-content state (first connect, window switches).
+    ///
+    /// `.image` mode locks to the screenshot branch — if the screenshot is
+    /// missing or undecodable, fall through to `.loading` rather than `.text`,
+    /// so the panel never silently revert to text mid-session.
+    /// `.text` mode locks to the text branch the same way.
     ///
     /// The URL tray above the content still renders regardless of branch,
     /// so tappable URLs remain available even while waiting for a screenshot.
-    static func branch(content: String, screenshot: String?) -> RenderBranch {
-        if let screenshot, let data = Data(base64Encoded: screenshot),
-           UIImage(data: data) != nil {
-            return .image
+    static func branch(content: String, screenshot: String?, mode: ContentRenderMode = .auto) -> RenderBranch {
+        let imageReady: Bool = {
+            guard let screenshot, let data = Data(base64Encoded: screenshot),
+                  UIImage(data: data) != nil else { return false }
+            return true
+        }()
+        switch mode {
+        case .image:
+            return imageReady ? .image : .loading
+        case .text:
+            return content.isEmpty ? .loading : .text
+        case .auto:
+            if imageReady { return .image }
+            if !content.isEmpty { return .text }
+            return .loading
         }
-        if !content.isEmpty { return .text }
-        return .loading
     }
 
     private var currentBranch: RenderBranch {
-        Self.branch(content: content, screenshot: screenshot)
+        Self.branch(content: content, screenshot: screenshot, mode: contentRenderMode)
+    }
+
+    /// Copy shown in the loading branch — distinguishes "auto / first
+    /// connect" from "you forced image/text and the corresponding payload
+    /// hasn't arrived yet" so the user knows it's waiting on data, not a
+    /// crashed renderer.
+    private var loadingPlaceholder: String {
+        switch contentRenderMode {
+        case .image: return "Waiting for screenshot…"
+        case .text:  return "Waiting for terminal text…"
+        case .auto:  return "Loading…"
+        }
     }
 
     /// Tiny pill in the header showing which render branch is live.
@@ -3207,7 +3258,7 @@ struct InlineTerminalContent: View {
                 LinkableTerminalText(content: content)
                     .frame(maxWidth: .infinity, maxHeight: .infinity)
             case .loading:
-                Text("Loading…")
+                Text(loadingPlaceholder)
                     .font(.system(size: 11))
                     .foregroundStyle(.white.opacity(0.4))
                     .frame(maxWidth: .infinity, maxHeight: .infinity)
@@ -3466,6 +3517,7 @@ struct SettingsSheet: View {
     @AppStorage("tintContentBorder") private var tintContentBorder = true
     @AppStorage("urlTrayEnabled") private var urlTrayEnabled = true
     @AppStorage("urlTrayLimit") private var urlTrayLimit = 10
+    @AppStorage("contentRenderMode") private var contentRenderModeRaw: String = ContentRenderMode.auto.rawValue
     @AppStorage("pushPaused") private var pushPaused = false
     @AppStorage("pushBannerEnabled") private var pushBannerEnabled = true
     @AppStorage("pushSound") private var pushSound = true
@@ -3492,7 +3544,7 @@ struct SettingsSheet: View {
                 // Appearance — tight single section. URL tray limit stepper
                 // sits inline behind the toggle so enabling the tray doesn't
                 // spawn a second row.
-                Section("Appearance") {
+                Section {
                     Toggle("Tint content panel border", isOn: $tintContentBorder)
                     HStack {
                         Toggle("URL tray", isOn: $urlTrayEnabled)
@@ -3503,6 +3555,16 @@ struct SettingsSheet: View {
                                 .foregroundStyle(.secondary)
                         }
                     }
+                    Picker("Content mode", selection: $contentRenderModeRaw) {
+                        ForEach(ContentRenderMode.allCases) { mode in
+                            Text(mode.label).tag(mode.rawValue)
+                        }
+                    }
+                    .pickerStyle(.segmented)
+                } header: {
+                    Text("Appearance")
+                } footer: {
+                    Text("Auto picks image when available, falls back to text. Image and Text lock the panel to one mode so it stops flickering when the Mac's screenshot stream drops out.")
                 }
 
                 // Notifications — one section. Kill switch on top; the

--- a/QuipiOS/QuipiOS.xcodeproj/project.pbxproj
+++ b/QuipiOS/QuipiOS.xcodeproj/project.pbxproj
@@ -28,6 +28,7 @@
 		3C69E42DAC8E6515F9BC3F03 /* WindowManagerSessionIdTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 764505DC63C7C214558A63CC /* WindowManagerSessionIdTests.swift */; };
 		413005C731BCDCED5438E47F /* InlineTerminalContentBranchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD67F0481CA1F97EEB2F5D7C /* InlineTerminalContentBranchTests.swift */; };
 		BAE1BE644A1C4697BEE9DB46 /* RecognizerRolloverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5803A385303C46EA4D51BE3 /* RecognizerRolloverTests.swift */; };
+		3EA86BE677664FD4A49B813D /* PhoneLayoutChooserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 859196B75583406E935B86A7 /* PhoneLayoutChooserTests.swift */; };
 		46B88647F52CB2FD8C378212 /* dictation-vocab.txt in Resources */ = {isa = PBXBuildFile; fileRef = 38403BB3D3EAD614680767A6 /* dictation-vocab.txt */; };
 		48F28455B8142325D6833C25 /* QuipTheme.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE693F49CD672CFD1507FDC6 /* QuipTheme.swift */; };
 		4D0689B3D9653512F27A322D /* BonjourBrowser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9EB84DC38B2B261AB78D9B78 /* BonjourBrowser.swift */; };
@@ -121,6 +122,7 @@
 		AB1FAB05086E60FFC302C3E6 /* ContextMenuView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContextMenuView.swift; sourceTree = "<group>"; };
 		AD67F0481CA1F97EEB2F5D7C /* InlineTerminalContentBranchTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InlineTerminalContentBranchTests.swift; sourceTree = "<group>"; };
 		B5803A385303C46EA4D51BE3 /* RecognizerRolloverTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecognizerRolloverTests.swift; sourceTree = "<group>"; };
+		859196B75583406E935B86A7 /* PhoneLayoutChooserTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PhoneLayoutChooserTests.swift; sourceTree = "<group>"; };
 		ADA867C4EE46E8D6EEA5EC8D /* PushRegistrationService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PushRegistrationService.swift; sourceTree = "<group>"; };
 		B3398B602525378B861B9218 /* Signing.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Signing.xcconfig; sourceTree = "<group>"; };
 		B5760F08A42C6C6570E49A4B /* WebSocketClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebSocketClient.swift; sourceTree = "<group>"; };
@@ -219,6 +221,7 @@
 				D6D5159A24459D33F4AE547B /* LinkifiedTerminalContentTests.swift */,
 				FFE14A146132EC2FDBF484D2 /* PTTStressTests.swift */,
 				B5803A385303C46EA4D51BE3 /* RecognizerRolloverTests.swift */,
+				859196B75583406E935B86A7 /* PhoneLayoutChooserTests.swift */,
 				BB799E5EBA5A72A97A8EDD06 /* RemoteSpeechSessionTests.swift */,
 				47C70308C62E57B9CBBEFF9E /* SpeechServicePathSelectionTests.swift */,
 				4A833238659B2E7E8D205F45 /* WhisperAudioSenderTests.swift */,
@@ -451,6 +454,7 @@
 				D574C92B13CDC64E5C200CAB /* PTTStressTests.swift in Sources */,
 				689A5ACEE675BEBE7608C903 /* PTTWindowTrackerTests.swift in Sources */,
 				BAE1BE644A1C4697BEE9DB46 /* RecognizerRolloverTests.swift in Sources */,
+				3EA86BE677664FD4A49B813D /* PhoneLayoutChooserTests.swift in Sources */,
 				034FCCCD9B6278E606AB7BBE /* RemoteSpeechSessionTests.swift in Sources */,
 				A795C27D5F398A26647E2B49 /* SeamStitcherTests.swift in Sources */,
 				1FED4AB0761613E80C3FAC9D /* SpeechServicePathSelectionTests.swift in Sources */,

--- a/QuipiOS/Services/HardwareButtonHandler.swift
+++ b/QuipiOS/Services/HardwareButtonHandler.swift
@@ -73,7 +73,9 @@ final class HardwareButtonHandler {
             try session.setCategory(.playAndRecord, mode: .default,
                                     options: [.mixWithOthers, .defaultToSpeaker])
             try session.setActive(true)
-        } catch {}
+        } catch {
+            NSLog("[Quip][HW] Audio session setup failed: %@", error.localizedDescription)
+        }
 
         // Preserve the user's current volume (and any audio another app like
         // YouTube is driving). Only nudge if we're parked on a rail where a
@@ -171,7 +173,9 @@ final class HardwareButtonHandler {
             try session.setCategory(.playAndRecord, mode: .default,
                                     options: [.mixWithOthers, .defaultToSpeaker])
             try session.setActive(true)
-        } catch {}
+        } catch {
+            NSLog("[Quip][HW] Audio session setup failed: %@", error.localizedDescription)
+        }
         primeRailIfNeeded(session: session)
     }
 

--- a/QuipiOS/Services/HardwareButtonHandler.swift
+++ b/QuipiOS/Services/HardwareButtonHandler.swift
@@ -13,6 +13,11 @@ final class HardwareButtonHandler {
     private static let volumeRestoreSuppression: TimeInterval = 0.3
     private static let pttTransitionSuppression: TimeInterval = 0.25
 
+    // iOS volume buttons step by 1/16. Stay one step away from each rail so
+    // KVO can always see motion in both directions.
+    private static let lowRail: Float = 0.0625
+    private static let highRail: Float = 0.9375
+
     var selectedIndex = 0
     private(set) var windowCount = 0
 
@@ -70,11 +75,10 @@ final class HardwareButtonHandler {
             try session.setActive(true)
         } catch {}
 
-        // Force volume to midpoint so both up and down always have room to change.
-        // We restore this midpoint after every button press.
-        savedVolume = 0.5
-        suppressUntil = Date().addingTimeInterval(Self.volumeRestoreSuppression)
-        HiddenVolumeView.setVolume(0.5)
+        // Preserve the user's current volume (and any audio another app like
+        // YouTube is driving). Only nudge if we're parked on a rail where a
+        // button press wouldn't produce a KVO delta.
+        primeRailIfNeeded(session: session)
 
         volumeObservation = session.observe(\.outputVolume, options: [.new, .old]) {
             [weak self] _, change in
@@ -168,8 +172,26 @@ final class HardwareButtonHandler {
                                     options: [.mixWithOthers, .defaultToSpeaker])
             try session.setActive(true)
         } catch {}
-        suppressUntil = Date().addingTimeInterval(Self.volumeRestoreSuppression)
-        HiddenVolumeView.setVolume(0.5)
+        primeRailIfNeeded(session: session)
+    }
+
+    /// Capture the user's current output volume into `savedVolume`. Only
+    /// override the system volume if it sits on a rail (≤low or ≥high) where
+    /// a button press wouldn't yield a KVO delta. Otherwise leave whatever
+    /// the user — or another foreground audio app — has set alone.
+    private func primeRailIfNeeded(session: AVAudioSession) {
+        let current = session.outputVolume
+        if current <= Self.lowRail {
+            savedVolume = Self.lowRail
+            suppressUntil = Date().addingTimeInterval(Self.volumeRestoreSuppression)
+            HiddenVolumeView.setVolume(Self.lowRail)
+        } else if current >= Self.highRail {
+            savedVolume = Self.highRail
+            suppressUntil = Date().addingTimeInterval(Self.volumeRestoreSuppression)
+            HiddenVolumeView.setVolume(Self.highRail)
+        } else {
+            savedVolume = current
+        }
     }
 
     func stopMonitoring() {

--- a/QuipiOS/Tests/InlineTerminalContentBranchTests.swift
+++ b/QuipiOS/Tests/InlineTerminalContentBranchTests.swift
@@ -67,4 +67,50 @@ final class InlineTerminalContentBranchTests: XCTestCase {
         let b = InlineTerminalContent.branch(content: "body", screenshot: "aGVsbG8=")
         XCTAssertEqual(b, .text, "base64 that doesn't decode to UIImage falls back to text, not Loading…")
     }
+
+    // MARK: - Explicit mode override (Settings → Appearance → Content mode)
+
+    func test_image_mode_with_screenshot_renders_image() {
+        let png = pngBase64()
+        let b = InlineTerminalContent.branch(content: "text here", screenshot: png, mode: .image)
+        XCTAssertEqual(b, .image)
+    }
+
+    func test_image_mode_without_screenshot_stays_loading_not_text() {
+        // The whole point of the override: never silently flip to text when
+        // the user has explicitly asked for image mode. Loading instead so
+        // they see the panel waiting rather than auto-falling back.
+        let b = InlineTerminalContent.branch(content: "text here", screenshot: nil, mode: .image)
+        XCTAssertEqual(b, .loading)
+    }
+
+    func test_image_mode_with_undecodable_screenshot_stays_loading() {
+        let b = InlineTerminalContent.branch(content: "text", screenshot: "not-base64-at-all!!!", mode: .image)
+        XCTAssertEqual(b, .loading)
+    }
+
+    func test_text_mode_with_content_renders_text_even_when_screenshot_present() {
+        // Inverse override: user wants text, screenshot is irrelevant.
+        let png = pngBase64()
+        let b = InlineTerminalContent.branch(content: "terminal output", screenshot: png, mode: .text)
+        XCTAssertEqual(b, .text)
+    }
+
+    func test_text_mode_without_content_is_loading() {
+        let b = InlineTerminalContent.branch(content: "", screenshot: nil, mode: .text)
+        XCTAssertEqual(b, .loading)
+    }
+
+    func test_auto_mode_matches_legacy_behavior() {
+        // Sanity: passing .auto explicitly == calling without the parameter.
+        let png = pngBase64()
+        XCTAssertEqual(
+            InlineTerminalContent.branch(content: "x", screenshot: png, mode: .auto),
+            InlineTerminalContent.branch(content: "x", screenshot: png)
+        )
+        XCTAssertEqual(
+            InlineTerminalContent.branch(content: "", screenshot: nil, mode: .auto),
+            InlineTerminalContent.branch(content: "", screenshot: nil)
+        )
+    }
 }

--- a/QuipiOS/Tests/PhoneLayoutChooserTests.swift
+++ b/QuipiOS/Tests/PhoneLayoutChooserTests.swift
@@ -1,0 +1,92 @@
+import XCTest
+import CoreGraphics
+@testable import Quip
+
+/// Tests for the pure-function bits of phone-side window layout — the
+/// auto-arrange chooser, the grid cell calculator, and the nearest-cell
+/// finder used by drag-to-snap. Live in pure fns on `MainiOSView` so a
+/// future refactor of the surrounding view code doesn't require setting
+/// up SwiftUI environments to verify the math.
+final class PhoneLayoutChooserTests: XCTestCase {
+
+    // MARK: chooseAutoLayout
+
+    func testChooserPicksHorizontalForOneWindow() {
+        XCTAssertEqual(MainiOSView.chooseAutoLayout(count: 1), "horizontal")
+    }
+
+    func testChooserPicksHorizontalForTwoWindows() {
+        XCTAssertEqual(MainiOSView.chooseAutoLayout(count: 2), "horizontal")
+    }
+
+    func testChooserPicksVerticalForThreeWindows() {
+        XCTAssertEqual(MainiOSView.chooseAutoLayout(count: 3), "vertical")
+    }
+
+    func testChooserPicksVerticalForManyWindows() {
+        XCTAssertEqual(MainiOSView.chooseAutoLayout(count: 10), "vertical")
+    }
+
+    // MARK: gridFrame
+
+    func testGridFrameHorizontalSplitsEvenly() {
+        let total = 4
+        for i in 0..<total {
+            let f = MainiOSView.gridFrame(mode: "horizontal", index: i, total: total)!
+            XCTAssertEqual(f.x, Double(i) * 0.25, accuracy: 1e-9)
+            XCTAssertEqual(f.y, 0)
+            XCTAssertEqual(f.width, 0.25, accuracy: 1e-9)
+            XCTAssertEqual(f.height, 1.0)
+        }
+    }
+
+    func testGridFrameVerticalSplitsEvenly() {
+        let total = 3
+        for i in 0..<total {
+            let f = MainiOSView.gridFrame(mode: "vertical", index: i, total: total)!
+            XCTAssertEqual(f.x, 0)
+            XCTAssertEqual(f.y, Double(i) / 3.0, accuracy: 1e-9)
+            XCTAssertEqual(f.width, 1.0)
+            XCTAssertEqual(f.height, 1.0 / 3.0, accuracy: 1e-9)
+        }
+    }
+
+    func testGridFrameUnknownModeReturnsNil() {
+        XCTAssertNil(MainiOSView.gridFrame(mode: "diagonal", index: 0, total: 4))
+    }
+
+    func testGridFrameOutOfRangeReturnsNil() {
+        XCTAssertNil(MainiOSView.gridFrame(mode: "horizontal", index: 5, total: 3))
+        XCTAssertNil(MainiOSView.gridFrame(mode: "horizontal", index: -1, total: 3))
+    }
+
+    func testGridFrameEmptyTotalReturnsNil() {
+        XCTAssertNil(MainiOSView.gridFrame(mode: "horizontal", index: 0, total: 0))
+    }
+
+    // MARK: nearestGridIndex
+
+    func testNearestGridIndexHorizontalDropOnSecondCell() {
+        // 4-cell horizontal grid: cell 1 center is at x=0.375, y=0.5.
+        let drop = CGPoint(x: 0.4, y: 0.5)
+        XCTAssertEqual(MainiOSView.nearestGridIndex(mode: "horizontal", total: 4, dropCenter: drop), 1)
+    }
+
+    func testNearestGridIndexVerticalDropOnLastCell() {
+        // 3-cell vertical grid: cell 2 center is at x=0.5, y=0.833.
+        let drop = CGPoint(x: 0.5, y: 0.85)
+        XCTAssertEqual(MainiOSView.nearestGridIndex(mode: "vertical", total: 3, dropCenter: drop), 2)
+    }
+
+    func testNearestGridIndexClampsToFirstWhenDropInLeftEdge() {
+        // 4-cell horizontal: cell 0 center at x=0.125. Drop at x=0 is closer
+        // to cell 0 than cell 1 (x=0.375).
+        let drop = CGPoint(x: 0, y: 0.5)
+        XCTAssertEqual(MainiOSView.nearestGridIndex(mode: "horizontal", total: 4, dropCenter: drop), 0)
+    }
+
+    func testNearestGridIndexClampsToLastWhenDropInRightEdge() {
+        let drop = CGPoint(x: 1.0, y: 0.5)
+        XCTAssertEqual(MainiOSView.nearestGridIndex(mode: "horizontal", total: 4, dropCenter: drop), 3)
+    }
+}

--- a/docs/superpowers/wishlist.md
+++ b/docs/superpowers/wishlist.md
@@ -836,3 +836,66 @@ Diagnosed autonomously via a Node.js fake-iOS-client (`/tmp/quip-content-probe.j
 - What about cross-display moves on the Mac? Phone has no notion of multiple displays in the layout view.
 
 **Related:** `QuipiOS/QuipApp.swift:2036` (`ForEach` placing `WindowRectangle`), `:2105` (`phoneLayoutFrame`), `:2119` (`windowRect` — coord conversion); `Shared/MessageProtocol.swift` (would need a new `set_window_frame` message if Mac mirroring is in scope).
+
+---
+
+### 41. Volume-button KVO must not clobber other-app audio (✅ Done, eb-branch)
+
+**Status:** ✅ Done on `eb-branch` — commit `1f5254c` (2026-04-26). Bug: opening Quip while YouTube/Spotify/etc. was playing slammed system volume to 0.5, "shooting up" any app with a lower-set volume.
+
+**What shipped:** `HardwareButtonHandler.startMonitoring` and `resumeAfterBackground` now call `primeRailIfNeeded(session:)` instead of unconditionally `setVolume(0.5)`. The helper reads `session.outputVolume`; if it's already in (0.0625, 0.9375) — i.e. button-press detection has headroom both directions — `savedVolume` is set to the user's actual level and the system volume is left alone. Only at the rails (≤0.0625 or ≥0.9375) does Quip nudge to the rail value so KVO can see motion.
+
+**Acceptance test:** Play YouTube at ~30 % volume, foreground Quip → volume stays at 30 %. Press volume up/down → cycle/PTT works, returns to 30 % after.
+
+**Related:** `QuipiOS/Services/HardwareButtonHandler.swift:62-81,158-176`.
+
+---
+
+### 42. Hardening audit 2026-04-26 — backlog (🟡 GitHub-tracked)
+
+**Status:** Filed as GitHub issues `jboert/Quip#10`–`#26` under label `audit-2026-04`. This wishlist entry is the index — the per-item detail lives in the issues. Tracker: [#26](https://github.com/jboert/Quip/issues/26).
+
+**Grades:** iOS security C+, iOS code quality A−, Mac security C, Mac robustness B+, build/signing B−, protocol design B+, repo hygiene B+, tests B−, docs B. **Overall B−.**
+
+**Critical (transport + sandboxing):**
+- §A `#10` — Re-enable TLS pinning in `WebSocketClient.swift:312-314`. Verify Cloudflare SPKI hashes first.
+- §B `#11` — Replace `NSAllowsArbitraryLoads: true` (`QuipiOS/project.yml:79`) with `NSExceptionDomains` allow-list (trycloudflare.com + `NSAllowsLocalNetworking`).
+- §C `#12` — Enable `com.apple.security.app-sandbox` in `QuipMac.entitlements`. Will trigger TCC re-prompts (Accessibility, Screen Recording) — schedule for a maintenance window.
+- §D `#13` — `ENABLE_HARDENED_RUNTIME: true` + `DEVELOPMENT_TEAM: D2PM6R797Q` in `QuipMac/project.yml`. Without these, notarization is impossible.
+
+**High (credentials + protocol):**
+- `#14` — Migrate Mac PIN from UserDefaults plaintext to Keychain (`PINManager.swift`); raise to 8+ alphanumeric.
+- `#15` — Audit `CloudflareTunnel.swift:80` Process spawn for `sh -c` shell injection; switch to argv array.
+- `#16` — Remove the 37 MB `cloudflared` Mach-O binary from git; fetch + checksum-verify in build script.
+- `#17` — Add per-message HMAC-SHA256 over WS (HKDF from PIN + nonces). Closes the post-auth-trust gap.
+
+**Medium (correctness + ops):**
+- `#18` — Idempotency keys (`requestId: UUID`) on `SendTextMessage` + `ImageUploadMessage`. Reconnect retries currently double-paste.
+- `#19` — Mac→iOS app-level heartbeat (5 s). Today only iOS pings; Mac crash leaves iOS in stale "connected" for ~13 s.
+- `#20` — Tighten message types: `arrange_windows.layout` → enum; consistent `(try? c.decode(...)) ?? nil` for optional fields.
+- `#21` — Lock `requireAuth` in `WebSocketServer.swift:27` (currently `nonisolated(unsafe)` — main writes, network queue reads).
+- `#22` — Move APNs `keyId` / `teamId` / `bundleId` from UserDefaults to Keychain (private key already there).
+- `#23` — Add CI: `xcodebuild test` for QuipiOS + QuipMac, `cargo test` for QuipLinux.
+- `#24` — Test gaps: WebSocket auth handshake, Mac message-handler dispatch, Bonjour discovery.
+
+**Low:**
+- `#25` — Expand `docs/protocol.md`: heartbeat, idempotency, Bonjour TXT, error envelope, "adding a new message" checklist.
+
+**Already shipped from this audit (commit `b6a8498`, eb-branch):**
+- `WebSocketServer.swift:375` — PIN values redacted from `/tmp` debug log (lengths only).
+- `HardwareButtonHandler.swift:76,174` — empty audio-session catches now `NSLog` the error.
+- `.gitignore` — `*.profraw` / `*.profdata` ignored.
+
+**Wins worth not breaking:**
+- `ImageUploadHandler.swift:13-71` — symlink resolution + prefix check + atomic write.
+- `WebSocketServer.swift:87,262-265` — two-layer 16 MiB cap (NWProtocolWebSocket + app-level guard).
+- iOS concurrency discipline: `@MainActor`, consistent `[weak self]`, `@ObservationIgnored` on background buffers.
+
+**Order of attack (suggested):**
+1. `#16` (cloudflared binary) and `#23` (CI) — pure ops, no runtime risk.
+2. `#15` (shell-injection check) — cheap investigation, may close as no-op.
+3. `#14` + `#22` (Keychain migrations) — one-shot, reversible.
+4. `#13` (team + hardened runtime) — flips one knob, blocks notarization until done.
+5. `#10` + `#11` together (transport hardening) — verify pins first, ship as one PR.
+6. `#12` (sandbox) — last because it's the TCC-prompting one.
+7. Protocol items (`#17`, `#18`, `#19`, `#20`) — bump protocol version once, ship together.

--- a/docs/superpowers/wishlist.md
+++ b/docs/superpowers/wishlist.md
@@ -791,3 +791,48 @@ Diagnosed autonomously via a Node.js fake-iOS-client (`/tmp/quip-content-probe.j
 ### 32. `mailto:` link support in terminal content
 
 **Status:** ✅ Done — extended the scheme filter in `linkifiedTerminalContent` to accept `mailto:` substring matches AND any URL whose `scheme` is "mailto" (NSDataDetector returns bare emails like `noreply@anthropic.com` as `mailto:noreply@anthropic.com` URLs natively, so both cases are covered). Two new unit tests: bare-email-as-mailto + explicit-mailto-uri. Tap pops the system Mail compose sheet via the standard URL handler.
+
+---
+
+### 39. Auto-arrange phone windows on open + manual realign button
+
+**Status:** Wishlist (run `/prd` to shape the chooser before coding).
+**Context:** When the iPhone Quip app opens and the windows list arrives from the Mac, cards land at the Mac's raw frame fractions. With ≥3 windows on a wide Mac display, the phone preview reads as cramped/overlapping rectangles even though the Mac arrangement is fine. User wants a sensible default phone-side layout to kick in automatically, plus a button to re-run it ("realign") whenever the auto-pick stops feeling right.
+
+**Likely shape:**
+- New default for `phoneLayoutOverride` (currently `nil` = use Mac's frames). On first non-empty windows snapshot per session, set it to a chooser-picked value (`"horizontal"` for ≤3 windows wide-orientation, `"vertical"` otherwise — exact heuristic TBD).
+- Add a "realign" button in the header — distinct from the existing arrange tri-state cycle button. Realign re-invokes the chooser; cycle keeps its current "step through modes" behavior. Or unify them — open question.
+- Persist last-used override per device count? Or reset every cold launch? `/prd` decides.
+- Likely needs a third layout mode: `"grid"` for 4+ windows (today only `horizontal` and `vertical` are wired in `phoneLayoutFrame` at QuipiOS/QuipApp.swift:2105).
+
+**Open questions for /prd:**
+- Auto-pick on every windows-list change, or only first one per session? (Latter avoids flicker when Mac side adds a window mid-session.)
+- Should the override be remembered across launches (`@AppStorage`) or always re-derived?
+- Does "realign" reset to the chooser pick, or open a chooser sheet (horizontal / vertical / grid / off)?
+- Interaction with §40 (drag-to-move): does realigning wipe per-window manual positions?
+
+**Related:** `QuipiOS/QuipApp.swift:655` (`phoneLayoutOverride` state), `:1526` (existing arrange-button cycle), `:2105` (`phoneLayoutFrame` chooser).
+
+---
+
+### 40. Drag-to-move windows on the iPhone layout
+
+**Status:** Wishlist (run `/prd` to lock semantics — phone-only vs Mac-mirror — before coding).
+**Context:** User wants to grab a window card on the iPhone preview and drop it somewhere else. Today every card's position comes from `phoneLayoutFrame` (auto-arrange override) or `window.frame` (Mac's raw frame). There's no per-window phone-side override, no drag gesture on `WindowRectangle`, no conflict resolution between dragged positions and auto-arrange.
+
+**Likely shape:**
+- New `@State` (or `@AppStorage` keyed by Mac UUID + windowId) `phoneFrameOverrides: [String: WindowFrame]`. Drag-end writes here; lookup in `windowLayout` ForEach checks it before `phoneLayoutFrame` and Mac frame.
+- DragGesture on the `WindowRectangle` view at QuipiOS/QuipApp.swift:2039. Translate fingertip delta into normalized fraction of the host-screen rect.
+- Snap behavior: free-drop, snap-to-grid (1/2 / 1/3 thirds), or swap-with-target-on-overlap. Last is most "discoverable for resizing the layout" but most code.
+- Visual feedback during drag: lift shadow, ghost the original position, target highlight if swap mode.
+- Coexistence with §39 auto-arrange: dragging clears the override mode (so user gets the manual frame instead of the auto pick) — or auto-arrange treats overridden windows as fixed and arranges the rest around them. Open Q.
+- Mac mirroring: does dragging on the phone also reposition the Mac window via AppleScript, or is this purely a phone-side preview tweak? `/prd` call.
+
+**Open questions for /prd:**
+- Phone-only preview, or mirror to Mac (heavier; needs Mac-side `set bounds of window` + reflow)?
+- Snap mode: free / grid / swap?
+- Resize-with-drag too, or just move? (Today Mac sets size; phone never resizes anything.)
+- How does this interact with §39's "realign" button — does realign wipe overrides or honor them?
+- What about cross-display moves on the Mac? Phone has no notion of multiple displays in the layout view.
+
+**Related:** `QuipiOS/QuipApp.swift:2036` (`ForEach` placing `WindowRectangle`), `:2105` (`phoneLayoutFrame`), `:2119` (`windowRect` — coord conversion); `Shared/MessageProtocol.swift` (would need a new `set_window_frame` message if Mac mirroring is in scope).


### PR DESCRIPTION
## Summary

Four commits, four logical changes — all phone/Mac-side polish.

- **URL tray** preserve last-good URLs across transient empty scrapes (`622061d`) — Mac sends `urls: nil` when extraction returns empty (transient iTerm scrape miss); iOS handler was wiping the tray on every bad refresh. Mirrored the screenshot preservation already in place.
- **Mac Settings** vertical-resize + About → Version row (`faf26c9`) — Settings window was hard-locked at 520×460. Long tabs (Connection has ~7 sections) clipped at the bottom. Width stays locked at 520 (no horizontal stretch); height now drag-resizable from a 460 floor. Version row pulls CFBundleShortVersionString + CFBundleVersion + binary mtime so install verification is one Settings open away.
- **Wishlist** §39 + §40 (`135da27`) — captured asks for phone auto-arrange + drag-to-move ahead of implementation.
- **Phone layout** auto-arrange, drag-to-move, configurable main row (`bb83a12`) — implements PRD §39 + §40. Chooser fires on every windows-list change (≤2 → horizontal, ≥3 → vertical), persists in `@AppStorage`. DragGesture on `WindowRectangle` with lift + ghost; release snaps to grid OR swaps if dropped on another card. First drag disengages auto-arrange. Long-press on the arrange-cycle button realigns. Each main-row button (chevrons, spawn, arrange, photo, keyboard, return) toggleable in Settings → Main Row Buttons; row reorganized into clusters with 10pt fixed gaps + flexible Spacers around the (always-visible) PTT mic.

## Test plan

- [ ] Mac Settings opens at 520×460, drag bottom edge → window grows vertically only (width stays locked, no right gutter)
- [ ] About → Version row shows version + build timestamp matching the install
- [ ] iPhone Quip cold launch with 3+ windows → cards stack vertically (auto-chooser pick), no overlap
- [ ] Tap arrange-cycle button → cycles horizontal/vertical, sticky after first manual cycle
- [ ] Long-press arrange-cycle button (0.5s) → drag overrides cleared + chooser re-fires + animated snap-back
- [ ] Drag a window card 100pt → lift effect (1.05× + shadow + dashed-border ghost at origin); release in empty space → snap to nearest auto-grid cell; release on another card → swap positions
- [ ] Settings → Main Row Buttons → toggle off Photo + Keyboard → row recenters around mic with no gaps where buttons used to be
- [ ] In iTerm, run `echo https://example.com`; on iPhone tap refresh → URL pill appears in the tray; tap pill → URL opens in browser
- [ ] PhoneLayoutChooserTests passes (13 cases)

🤖 Generated with [Claude Code](https://claude.com/claude-code)