### PR TITLE
iOS Quick Buttons editor + Mac build fixes

### DIFF
--- a/QuipMac/QuipMac.xcodeproj/project.pbxproj
+++ b/QuipMac/QuipMac.xcodeproj/project.pbxproj
@@ -12,6 +12,7 @@
 		107399D353901EBFF5FB310B /* NetworkMode.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2BE934418962AAB550CF87F /* NetworkMode.swift */; };
 		116314BEF65175C6546B7FD6 /* PushRegisteredDeviceStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C4E4F97BA0BB789B8E2A1D6 /* PushRegisteredDeviceStoreTests.swift */; };
 		13D5412FA1D65684388478B6 /* MirrorDesktopFilterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 589E484D563BAA76B0634F61 /* MirrorDesktopFilterTests.swift */; };
+		14DAC6065803A0A60587E902 /* AuthThrottleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 12DF63C5377F483607D75CFB /* AuthThrottleTests.swift */; };
 		15E7F693296D17701B7805E9 /* KeystrokeInjectorWriteExpressionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E37933B6AB818F38B0D7418F /* KeystrokeInjectorWriteExpressionTests.swift */; };
 		166D5EA3635FC5603D18D5A6 /* TailscaleService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88BE6CF66C22B39C6DAACAA1 /* TailscaleService.swift */; };
 		19BF72AF894F3D230BA2B8A6 /* ArrangeLayoutMappingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B5A07701D8FE93394003C87 /* ArrangeLayoutMappingTests.swift */; };
@@ -37,22 +38,22 @@
 		776B6808FFB2C42DE93FF535 /* TerminalURLExtractorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 792D57DC8FC3B11646E7AA24 /* TerminalURLExtractorTests.swift */; };
 		7893732742065279CC924FCF /* ImageUploadMessageTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BDEBA5C1FF3ADA484633B4B /* ImageUploadMessageTests.swift */; };
 		7DE0BC0A1355E4517B96429A /* WhisperDictationService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E95B5D735BD68D7B185A9E1 /* WhisperDictationService.swift */; };
-		E220A3E42AB5D1FCB387DB39 /* WhisperStatusStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02DCCC03C74A5FBFE2A31E86 /* WhisperStatusStore.swift */; };
 		82C001C2D1E751B52E9323D6 /* WindowManagerSessionIdTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F2FC54EF7BE5384458CC160 /* WindowManagerSessionIdTests.swift */; };
 		864A7798EAC351C8B5E8E39F /* Color+Hex.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2B19559A6253B0E85D5C581 /* Color+Hex.swift */; };
 		879115E516EAFBE69CFC6E51 /* SeamStitcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E62E57A20864587E11C9636 /* SeamStitcher.swift */; };
 		8A417F2510A72EBDC859412C /* ConnectionLog.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F2F800B05C6E3B1022489FD /* ConnectionLog.swift */; };
 		9084D0AD136CA9E40A96DE7E /* PushNotificationService.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5BBF33D3BEF237F79631FBD /* PushNotificationService.swift */; };
+		90DC0538AD2AB94DCA09D040 /* QuipMacApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = "TEMP_E4F461ED-D031-4544-8979-2AEEBBB87589" /* QuipMacApp.swift */; };
+		99CB71752F02DDBC17142390 /* AuthThrottle.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9B0051B1E4D19C01D69982E /* AuthThrottle.swift */; };
 		9B4D46C0E2C0623E6F9BE1C6 /* MainWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C947C022B2F6D1CB4FED43F /* MainWindow.swift */; };
 		9E9263F5B804961A1B7225A8 /* KokoroTTS.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6ED3CA65D3DE8E2C7DCF5769 /* KokoroTTS.swift */; };
 		A81002D85A2BC5AA5976AFCF /* WebSocketServer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3EC90466A8AD9BEAE5A07DDC /* WebSocketServer.swift */; };
 		AF54B4FBF351780F625437CA /* TerminalURLExtractor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73FCC8550866B2D7A72DE1C5 /* TerminalURLExtractor.swift */; };
-		B1BEE7B5BECFD3765E7D5267 /* QuipMacApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = "TEMP_2E072244-DFEF-4323-9C64-9CABF1D39773" /* QuipMacApp.swift */; };
+		AF8CF9B66ACCC53E3CF2B4FA /* LogPaths.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1BB74E325653A8DA71C1B8EA /* LogPaths.swift */; };
 		B8F784DAB51BBEBD94DE4D1A /* APNsJWTTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FBBECC11724C6B7430E8A8DA /* APNsJWTTests.swift */; };
 		BB7AD29C435EAFFE6F8DED12 /* MenuBarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 81BB452979FFEEB64D818B68 /* MenuBarView.swift */; };
 		BF0FBA9E0D24561D417C885D /* ImageUploadHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B0B9C724A81CC5A243284D8 /* ImageUploadHandler.swift */; };
 		BFAEC96E6C28193C492E7873 /* KeystrokeFocusDelayTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45F9BC10D98A7C867B02D5A1 /* KeystrokeFocusDelayTests.swift */; };
-		C09350BC0C5C8DBF3CDD2C4C /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = "TEMP_130EA969-08A0-40D7-8CFA-8945CCCC4DB8" /* Assets.xcassets */; };
 		C3E6AD2C931293FB771CF8CC /* ImageUploadHandlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9432A677E617A6B09DA7DD0B /* ImageUploadHandlerTests.swift */; };
 		C68B39F81066E2B42D55AE69 /* APNsKeyStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 81E08E6062A74F4982F5FA16 /* APNsKeyStore.swift */; };
 		CA061A5EA5E9FFFED7B88CA6 /* kokoro_tts.py in Resources */ = {isa = PBXBuildFile; fileRef = 68BD4937C2DB6DD04A719C32 /* kokoro_tts.py */; };
@@ -62,12 +63,15 @@
 		DB25E0C4E38ECC8B9A42D04D /* PermissionProbeService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E4A88C19C3BFF8C38C0B2E4 /* PermissionProbeService.swift */; };
 		E1671AA42F6C302F2E176941 /* ClaudeModeScannerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7E1DC52BCF5C78516007D8A /* ClaudeModeScannerTests.swift */; };
 		E16F140F49A779C15EAA0862 /* SecretRedactor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7F854257F09ED55190DA9754 /* SecretRedactor.swift */; };
+		E3D52168C6ED0D7E035F86C8 /* WhisperStatusStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79CCA0A3EEB84C493F8E430E /* WhisperStatusStore.swift */; };
 		EB8C0145B42599AFC038A801 /* WindowManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A1FEC6C97F916BC3E12CC91 /* WindowManager.swift */; };
 		F0476745D4BE09BEA5E6FA79 /* AuditLogger.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FFBB5F208F16F99E170009A /* AuditLogger.swift */; };
 		F052F06C47112A9B96B81D1F /* PCMChunkerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2165769DE1070C93A139C24 /* PCMChunkerTests.swift */; };
 		F0BDBE94C7CB5AD6685E33E5 /* BonjourAdvertiser.swift in Sources */ = {isa = PBXBuildFile; fileRef = EBFB66F35E0DB7CFEA44761B /* BonjourAdvertiser.swift */; };
+		F0CC2171B9BC801516463331 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = "TEMP_0E86A77D-D4DA-4DEC-AE4C-B70F93EF0131" /* Assets.xcassets */; };
 		F6BAA00D69BD1F037B3D22A1 /* TerminalColorManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE4C92DB2B69AF079BEC6369 /* TerminalColorManager.swift */; };
 		F77CFDC85D04FA667F66028B /* AudioRingBufferTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6789468087C0DADB2E58869D /* AudioRingBufferTests.swift */; };
+		FB072CFAFE2EFEBE82AC01D4 /* Constants.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD884FDC1F567F0F5B50B23C /* Constants.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -83,6 +87,8 @@
 /* Begin PBXFileReference section */
 		06BBCCD34532C15A5A05B49A /* PINManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PINManager.swift; sourceTree = "<group>"; };
 		11E45D24608373377E2D46D3 /* ClaudeModeDetector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClaudeModeDetector.swift; sourceTree = "<group>"; };
+		12DF63C5377F483607D75CFB /* AuthThrottleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthThrottleTests.swift; sourceTree = "<group>"; };
+		1BB74E325653A8DA71C1B8EA /* LogPaths.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LogPaths.swift; sourceTree = "<group>"; };
 		2212F34B839B3C63906BAD2C /* CloudflareTunnel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CloudflareTunnel.swift; sourceTree = "<group>"; };
 		2B0B9C724A81CC5A243284D8 /* ImageUploadHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageUploadHandler.swift; sourceTree = "<group>"; };
 		2E4A88C19C3BFF8C38C0B2E4 /* PermissionProbeService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PermissionProbeService.swift; sourceTree = "<group>"; };
@@ -98,7 +104,6 @@
 		5B283E1205AA8D907541BB47 /* QuipMacTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = QuipMacTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		5BDEBA5C1FF3ADA484633B4B /* ImageUploadMessageTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageUploadMessageTests.swift; sourceTree = "<group>"; };
 		5E95B5D735BD68D7B185A9E1 /* WhisperDictationService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WhisperDictationService.swift; sourceTree = "<group>"; };
-		02DCCC03C74A5FBFE2A31E86 /* WhisperStatusStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WhisperStatusStore.swift; sourceTree = "<group>"; };
 		6789468087C0DADB2E58869D /* AudioRingBufferTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioRingBufferTests.swift; sourceTree = "<group>"; };
 		682D1CC11B830E8D9F079FB7 /* SeamStitcherTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SeamStitcherTests.swift; sourceTree = "<group>"; };
 		68BD4937C2DB6DD04A719C32 /* kokoro_tts.py */ = {isa = PBXFileReference; lastKnownFileType = text.script.python; path = kokoro_tts.py; sourceTree = "<group>"; };
@@ -109,6 +114,7 @@
 		6F2F800B05C6E3B1022489FD /* ConnectionLog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConnectionLog.swift; sourceTree = "<group>"; };
 		73FCC8550866B2D7A72DE1C5 /* TerminalURLExtractor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalURLExtractor.swift; sourceTree = "<group>"; };
 		792D57DC8FC3B11646E7AA24 /* TerminalURLExtractorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalURLExtractorTests.swift; sourceTree = "<group>"; };
+		79CCA0A3EEB84C493F8E430E /* WhisperStatusStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WhisperStatusStore.swift; sourceTree = "<group>"; };
 		7B772AF07D680F56F89EEA91 /* AudioRingBuffer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioRingBuffer.swift; sourceTree = "<group>"; };
 		7C72FAA7988E0CA53E9ADCCD /* QuipMac.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = QuipMac.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		7F854257F09ED55190DA9754 /* SecretRedactor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SecretRedactor.swift; sourceTree = "<group>"; };
@@ -131,8 +137,10 @@
 		B5EFE906905D43F124D49A7A /* LayoutPreview.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LayoutPreview.swift; sourceTree = "<group>"; };
 		C4F88E483BBB2954E4D41D7B /* PCMChunker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PCMChunker.swift; sourceTree = "<group>"; };
 		C57A110912607ACED6E89B19 /* LayoutPresetTabs.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LayoutPresetTabs.swift; sourceTree = "<group>"; };
+		C9B0051B1E4D19C01D69982E /* AuthThrottle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthThrottle.swift; sourceTree = "<group>"; };
 		CD34B2B54B885CCB7A223934 /* WhisperDictationServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WhisperDictationServiceTests.swift; sourceTree = "<group>"; };
 		CD526E4C21F232FACDCD3F3F /* DefaultLayouts.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = DefaultLayouts.json; sourceTree = "<group>"; };
+		CD884FDC1F567F0F5B50B23C /* Constants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Constants.swift; sourceTree = "<group>"; };
 		E37933B6AB818F38B0D7418F /* KeystrokeInjectorWriteExpressionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeystrokeInjectorWriteExpressionTests.swift; sourceTree = "<group>"; };
 		EBFB66F35E0DB7CFEA44761B /* BonjourAdvertiser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BonjourAdvertiser.swift; sourceTree = "<group>"; };
 		EFB206BDF80C59B557B5561A /* MessageProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageProtocol.swift; sourceTree = "<group>"; };
@@ -141,9 +149,9 @@
 		FBAFA76040229EEE779AC055 /* WindowListSidebar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WindowListSidebar.swift; sourceTree = "<group>"; };
 		FBBECC11724C6B7430E8A8DA /* APNsJWTTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APNsJWTTests.swift; sourceTree = "<group>"; };
 		FE4C92DB2B69AF079BEC6369 /* TerminalColorManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalColorManager.swift; sourceTree = "<group>"; };
-		"TEMP_130EA969-08A0-40D7-8CFA-8945CCCC4DB8" /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
-		"TEMP_2838D826-6CA3-4702-85B9-4007FB21E459" /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
-		"TEMP_2E072244-DFEF-4323-9C64-9CABF1D39773" /* QuipMacApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuipMacApp.swift; sourceTree = "<group>"; };
+		"TEMP_0E86A77D-D4DA-4DEC-AE4C-B70F93EF0131" /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		"TEMP_6A57F206-751E-495C-9EFA-E955354125A9" /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
+		"TEMP_E4F461ED-D031-4544-8979-2AEEBBB87589" /* QuipMacApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuipMacApp.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -162,6 +170,7 @@
 			isa = PBXGroup;
 			children = (
 				FBBECC11724C6B7430E8A8DA /* APNsJWTTests.swift */,
+				12DF63C5377F483607D75CFB /* AuthThrottleTests.swift */,
 				A7E1DC52BCF5C78516007D8A /* ClaudeModeScannerTests.swift */,
 				9432A677E617A6B09DA7DD0B /* ImageUploadHandlerTests.swift */,
 				4AF071C3CBB7547A6D15F74D /* ITermWindowListParserTests.swift */,
@@ -179,6 +188,7 @@
 				F5D9089FAA12F8CDF0710813 /* APNsClient.swift */,
 				81E08E6062A74F4982F5FA16 /* APNsKeyStore.swift */,
 				3FFBB5F208F16F99E170009A /* AuditLogger.swift */,
+				C9B0051B1E4D19C01D69982E /* AuthThrottle.swift */,
 				EBFB66F35E0DB7CFEA44761B /* BonjourAdvertiser.swift */,
 				11E45D24608373377E2D46D3 /* ClaudeModeDetector.swift */,
 				2212F34B839B3C63906BAD2C /* CloudflareTunnel.swift */,
@@ -186,6 +196,7 @@
 				2B0B9C724A81CC5A243284D8 /* ImageUploadHandler.swift */,
 				A56A336266F29BFDA4CB1C10 /* KeystrokeInjector.swift */,
 				6ED3CA65D3DE8E2C7DCF5769 /* KokoroTTS.swift */,
+				1BB74E325653A8DA71C1B8EA /* LogPaths.swift */,
 				B2BE934418962AAB550CF87F /* NetworkMode.swift */,
 				2E4A88C19C3BFF8C38C0B2E4 /* PermissionProbeService.swift */,
 				06BBCCD34532C15A5A05B49A /* PINManager.swift */,
@@ -197,7 +208,7 @@
 				73FCC8550866B2D7A72DE1C5 /* TerminalURLExtractor.swift */,
 				3EC90466A8AD9BEAE5A07DDC /* WebSocketServer.swift */,
 				5E95B5D735BD68D7B185A9E1 /* WhisperDictationService.swift */,
-				02DCCC03C74A5FBFE2A31E86 /* WhisperStatusStore.swift */,
+				79CCA0A3EEB84C493F8E430E /* WhisperStatusStore.swift */,
 				3A1FEC6C97F916BC3E12CC91 /* WindowManager.swift */,
 			);
 			path = Services;
@@ -279,6 +290,7 @@
 			isa = PBXGroup;
 			children = (
 				7B772AF07D680F56F89EEA91 /* AudioRingBuffer.swift */,
+				CD884FDC1F567F0F5B50B23C /* Constants.swift */,
 				EFB206BDF80C59B557B5561A /* MessageProtocol.swift */,
 				C4F88E483BBB2954E4D41D7B /* PCMChunker.swift */,
 				4D27715C83416E12D0A2488F /* PTTWindowTracker.swift */,
@@ -297,12 +309,12 @@
 			path = Resources;
 			sourceTree = "<group>";
 		};
-		"TEMP_E1C0172C-D235-4DBB-A8AB-3A6A3B43AC94" /* QuipMac */ = {
+		"TEMP_04955270-CA44-4D1C-9A4F-55DCE0F2815C" /* QuipMac */ = {
 			isa = PBXGroup;
 			children = (
-				"TEMP_2E072244-DFEF-4323-9C64-9CABF1D39773" /* QuipMacApp.swift */,
-				"TEMP_130EA969-08A0-40D7-8CFA-8945CCCC4DB8" /* Assets.xcassets */,
-				"TEMP_2838D826-6CA3-4702-85B9-4007FB21E459" /* Info.plist */,
+				"TEMP_E4F461ED-D031-4544-8979-2AEEBBB87589" /* QuipMacApp.swift */,
+				"TEMP_0E86A77D-D4DA-4DEC-AE4C-B70F93EF0131" /* Assets.xcassets */,
+				"TEMP_6A57F206-751E-495C-9EFA-E955354125A9" /* Info.plist */,
 				F621177D73579FB347509BD2 /* Resources */,
 				D32FA749E86D0C4ECD728F1E /* Models */,
 				D87702261819716197ADF4C3 /* Views */,
@@ -395,7 +407,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				C09350BC0C5C8DBF3CDD2C4C /* Assets.xcassets in Resources */,
+				F0CC2171B9BC801516463331 /* Assets.xcassets in Resources */,
 				425DCC822BD1C987A508873B /* DefaultLayouts.json in Resources */,
 				CA061A5EA5E9FFFED7B88CA6 /* kokoro_tts.py in Resources */,
 			);
@@ -433,17 +445,20 @@
 				C68B39F81066E2B42D55AE69 /* APNsKeyStore.swift in Sources */,
 				5322A857B9208D76DBF6E503 /* AudioRingBuffer.swift in Sources */,
 				F0476745D4BE09BEA5E6FA79 /* AuditLogger.swift in Sources */,
+				99CB71752F02DDBC17142390 /* AuthThrottle.swift in Sources */,
 				F0BDBE94C7CB5AD6685E33E5 /* BonjourAdvertiser.swift in Sources */,
 				6206170D640DFCB204C0CD84 /* ClaudeModeDetector.swift in Sources */,
 				CDECFE9CA16389D2F1B455D5 /* CloudflareTunnel.swift in Sources */,
 				864A7798EAC351C8B5E8E39F /* Color+Hex.swift in Sources */,
 				8A417F2510A72EBDC859412C /* ConnectionLog.swift in Sources */,
+				FB072CFAFE2EFEBE82AC01D4 /* Constants.swift in Sources */,
 				BF0FBA9E0D24561D417C885D /* ImageUploadHandler.swift in Sources */,
 				6A687DBD83641F9456CDB731 /* KeystrokeInjector.swift in Sources */,
 				9E9263F5B804961A1B7225A8 /* KokoroTTS.swift in Sources */,
 				1A23A388645C53D6E41A1238 /* LayoutPreset.swift in Sources */,
 				4C1F7E7F9836B4D3EF5D6FD7 /* LayoutPresetTabs.swift in Sources */,
 				0553EF1A21F0C774DAA2F0D6 /* LayoutPreview.swift in Sources */,
+				AF8CF9B66ACCC53E3CF2B4FA /* LogPaths.swift in Sources */,
 				9B4D46C0E2C0623E6F9BE1C6 /* MainWindow.swift in Sources */,
 				BB7AD29C435EAFFE6F8DED12 /* MenuBarView.swift in Sources */,
 				3E80AB53764777CE3E79A463 /* MessageProtocol.swift in Sources */,
@@ -454,7 +469,7 @@
 				1BFFDD98C1E1578755E3B874 /* PTTWindowTracker.swift in Sources */,
 				DB25E0C4E38ECC8B9A42D04D /* PermissionProbeService.swift in Sources */,
 				9084D0AD136CA9E40A96DE7E /* PushNotificationService.swift in Sources */,
-				B1BEE7B5BECFD3765E7D5267 /* QuipMacApp.swift in Sources */,
+				90DC0538AD2AB94DCA09D040 /* QuipMacApp.swift in Sources */,
 				879115E516EAFBE69CFC6E51 /* SeamStitcher.swift in Sources */,
 				E16F140F49A779C15EAA0862 /* SecretRedactor.swift in Sources */,
 				63FE4D9F58CCE850B4F8D7FE /* SettingsView.swift in Sources */,
@@ -464,7 +479,7 @@
 				AF54B4FBF351780F625437CA /* TerminalURLExtractor.swift in Sources */,
 				A81002D85A2BC5AA5976AFCF /* WebSocketServer.swift in Sources */,
 				7DE0BC0A1355E4517B96429A /* WhisperDictationService.swift in Sources */,
-				E220A3E42AB5D1FCB387DB39 /* WhisperStatusStore.swift in Sources */,
+				E3D52168C6ED0D7E035F86C8 /* WhisperStatusStore.swift in Sources */,
 				44D85DED79B8403CA7AE7459 /* WindowInfo.swift in Sources */,
 				D771CA86FD23E660375CC1AC /* WindowListSidebar.swift in Sources */,
 				EB8C0145B42599AFC038A801 /* WindowManager.swift in Sources */,
@@ -478,6 +493,7 @@
 				B8F784DAB51BBEBD94DE4D1A /* APNsJWTTests.swift in Sources */,
 				19BF72AF894F3D230BA2B8A6 /* ArrangeLayoutMappingTests.swift in Sources */,
 				F77CFDC85D04FA667F66028B /* AudioRingBufferTests.swift in Sources */,
+				14DAC6065803A0A60587E902 /* AuthThrottleTests.swift in Sources */,
 				E1671AA42F6C302F2E176941 /* ClaudeModeScannerTests.swift in Sources */,
 				CB4CE20C3C4CB1AA46978892 /* ITermWindowListParserTests.swift in Sources */,
 				C3E6AD2C931293FB771CF8CC /* ImageUploadHandlerTests.swift in Sources */,

--- a/QuipMac/QuipMacApp.swift
+++ b/QuipMac/QuipMacApp.swift
@@ -1297,12 +1297,22 @@ struct QuipMacApp: App {
     /// tells the user to use the manual `press_shift_tab` action instead.
     @MainActor
     private func cycleClaudeMode(to target: ClaudeMode, for window: ManagedWindow) {
-        let current = claudeModeDetector.windowModes[window.id] ?? .normal
-        let knownMode = claudeModeDetector.windowModes[window.id] != nil
-
-        if !knownMode {
-            // No detected indicator yet — refuse to press blind. Tell the user.
-            let err = ErrorMessage(reason: "Can't detect current Claude mode for \(window.name) — press Shift+Tab manually until you see the right indicator.")
+        // The mode scanner only emits a positive value for plan / autoAccept
+        // (those have visible indicator strings). Normal mode has no indicator,
+        // so the detector returns nil for it — same nil value it returns when
+        // Claude isn't running at all. Disambiguate via `windowsWithClaudeProcess`:
+        // if Claude IS running and no indicator was found, the window is in normal
+        // mode by elimination. Without this fallback the plan-mode button refused
+        // to press whenever the user was starting from a fresh normal-mode prompt.
+        let detected = claudeModeDetector.windowModes[window.id]
+        let claudeRunning = terminalStateDetector.windowsWithClaudeProcess.contains(window.id)
+        let current: ClaudeMode
+        if let detected {
+            current = detected
+        } else if claudeRunning {
+            current = .normal
+        } else {
+            let err = ErrorMessage(reason: "Claude doesn't appear to be running in \(window.name) — start it (`claude`) or press Shift+Tab manually.")
             webSocketServer.broadcast(err)
             return
         }

--- a/QuipMac/Services/WebSocketServer.swift
+++ b/QuipMac/Services/WebSocketServer.swift
@@ -29,6 +29,11 @@ final class WebSocketServer {
     private var listener: NWListener?
     private var clients: [ClientConnection] = []
     private let networkQueue = DispatchQueue(label: "quip.websocket", qos: .userInitiated)
+    /// Retry interval when the listener can't bind (e.g. port 8765 squatted by
+    /// another process). Without this the server would give up silently and the
+    /// phone would talk to whatever is on 8765 and report "bad response from server".
+    nonisolated private static let bindRetryInterval: TimeInterval = 5
+    private var bindRetryWorkItem: DispatchWorkItem?
 
     /// Tracks a WebSocket connection, its authentication state, and rate limiting.
     private struct ClientConnection {
@@ -91,7 +96,13 @@ final class WebSocketServer {
         do {
             listener = try NWListener(using: parameters, on: 8765)
         } catch {
-            print("[WebSocketServer] Failed to create listener: \(error)")
+            print("[WebSocketServer] Failed to create listener: \(error) — retrying in \(Self.bindRetryInterval)s")
+            connectionLog?.record(
+                .failed,
+                remote: "listener:8765",
+                detail: "bind failed: \(error) — will retry"
+            )
+            scheduleBindRetry()
             return
         }
 
@@ -107,9 +118,17 @@ final class WebSocketServer {
                     print("[WebSocketServer] Listening on localhost:\(port)")
                 }
             case .failed(let error):
-                print("[WebSocketServer] Listener failed: \(error)")
+                print("[WebSocketServer] Listener failed: \(error) — retrying in \(Self.bindRetryInterval)s")
                 DispatchQueue.main.async {
                     self.isRunning = false
+                    self.connectionLog?.record(
+                        .failed,
+                        remote: "listener:8765",
+                        detail: "listener failed: \(error) — will retry"
+                    )
+                    self.listener?.cancel()
+                    self.listener = nil
+                    self.scheduleBindRetry()
                 }
             case .cancelled:
                 DispatchQueue.main.async {
@@ -182,7 +201,23 @@ final class WebSocketServer {
         listener.start(queue: networkQueue)
     }
 
+    /// Schedule a single-shot retry of `start()`. Idempotent — replaces any
+    /// already-pending retry so we don't stack timers when `.failed` fires
+    /// repeatedly.
+    private func scheduleBindRetry() {
+        bindRetryWorkItem?.cancel()
+        let work = DispatchWorkItem { [weak self] in
+            guard let self else { return }
+            self.bindRetryWorkItem = nil
+            self.start()
+        }
+        bindRetryWorkItem = work
+        DispatchQueue.main.asyncAfter(deadline: .now() + Self.bindRetryInterval, execute: work)
+    }
+
     func stop() {
+        bindRetryWorkItem?.cancel()
+        bindRetryWorkItem = nil
         listener?.cancel()
         listener = nil
         for client in clients {

--- a/QuipiOS/QuipApp.swift
+++ b/QuipiOS/QuipApp.swift
@@ -638,6 +638,13 @@ struct MainiOSView: View {
     // command, the Y/N confirmations that Claude asks for, Esc to dismiss,
     // and Ctrl+C to abort. Everything else is opt-in from Settings.
     @AppStorage("enabledQuickButtons") private var enabledQuickButtonsRaw: String = "plan,yes,no,esc,ctrlC"
+    // New ordered slot list — supersedes the CSV above. JSON-encoded
+    // `[QuickSlot]`. Empty string triggers migration from the CSV on first
+    // read (see `effectiveQuickSlots` in MainiOSView).
+    @AppStorage("quickSlotsJSON") private var quickSlotsJSON: String = ""
+    // User-defined custom buttons. JSON-encoded `[CustomButton]`. Defaults
+    // to "[]". Slots reference these by UUID via `.custom(id)`.
+    @AppStorage("customButtonsJSON") private var customButtonsJSON: String = "[]"
     // Per-button toggles for the main control row (chevrons, spawn, arrange,
     // photo, keyboard, return). PTT mic and the row itself stay mandatory.
     // Default ON — existing users keep their current button set.
@@ -853,6 +860,14 @@ struct MainiOSView: View {
         .environment(\.quipColors, colors)
         .onAppear {
             updateOrientation()
+            // One-shot migration of the legacy CSV `enabledQuickButtons`
+            // representation to the new ordered slot list. Empty JSON =
+            // never migrated; running version puts `quickSlotsJSON` in a
+            // valid state so `effectiveQuickSlots` stays a pure read.
+            if quickSlotsJSON.isEmpty {
+                let migrated = QuickSlotStore.migrate(fromCSV: enabledQuickButtonsRaw)
+                quickSlotsJSON = QuickSlotStore.encode(migrated)
+            }
             // Restore persisted phone-side window overrides so a returning
             // user sees their drag layout before the first windows-list
             // arrives. No-op on first launch (empty JSON → empty dict).
@@ -1754,44 +1769,22 @@ struct MainiOSView: View {
                 // reachable in one thumb-sweep. Portrait keeps the 2-row
                 // layout below because there isn't width to spare.
                 if !isPortrait {
-                    let enabled = QuickButton.decode(enabledQuickButtonsRaw)
-                    if !enabled.isEmpty {
-                        let landscapeSlash = enabled.filter { $0.isSlashCommand || $0 == .slash }
-                        let landscapeRest = enabled.filter { !($0.isSlashCommand || $0 == .slash) }
+                    let slots = effectiveQuickSlots
+                    if !slots.isEmpty {
                         Spacer().frame(width: 8)
-                        slashRowView(landscapeSlash)
-                        if !landscapeSlash.isEmpty, !landscapeRest.isEmpty {
-                            Spacer().frame(width: 6)
-                        }
-                        ForEach(landscapeRest) { quickActionButton($0) }
+                        slotRowView(slots)
                     }
                 }
             }
 
-            // Portrait-only secondary command-shortcut row. Buttons are
-            // grouped left/center/right by category so the center group
-            // (answers — Y/N/1/2/3) lines up vertically with the mic
-            // above, which is also Spacer-pinned to the row's center.
+            // Portrait-only secondary command-shortcut row. Slots render in
+            // user-controlled order — they place `.spacer` slots themselves
+            // via the editor (Apple-toolbar-style customization).
             if isPortrait {
-                let enabled = QuickButton.decode(enabledQuickButtonsRaw)
-                if !enabled.isEmpty {
-                    let slash = enabled.filter { $0.category == .slash }
-                    let yesNo = enabled.filter { $0 == .yes || $0 == .no }
-                    let numbers = enabled.filter { $0 == .one || $0 == .two || $0 == .three }
-                    let keystroke = enabled.filter { $0.category == .keystroke }
+                let slots = effectiveQuickSlots
+                if !slots.isEmpty {
                     HStack(spacing: 3) {
-                        slashRowView(slash)
-                        Spacer(minLength: 6)
-                        ForEach(yesNo) { quickActionButton($0) }
-                        // Small fixed gap between Y/N (confirmations) and
-                        // 1/2/3 (numbered choices) — both are "answers" but
-                        // visually distinct sub-groups.
-                        if !yesNo.isEmpty, !numbers.isEmpty {
-                            Spacer().frame(width: 8)
-                        }
-                        ForEach(numbers) { quickActionButton($0) }
-                        Spacer(minLength: 6)
-                        ForEach(keystroke) { quickActionButton($0) }
+                        slotRowView(slots)
                     }
                     .padding(.horizontal, 6)
                 }
@@ -2720,51 +2713,153 @@ struct MainiOSView: View {
         }
     }
 
-    /// First letter after the leading "/" for slash-command buttons (e.g. "c"
-    /// for "/clear"). Returns nil for non-slash actions or the bare "/".
-    private func slashLetter(of button: QuickButton) -> Character? {
-        guard button.isSlashCommand, button != .slash else { return nil }
-        let s = button.displayName
-        guard s.count >= 2, s.first == "/" else { return nil }
-        return s[s.index(after: s.startIndex)].lowercased().first
+    /// Decoded custom-button definitions table. Read from JSON @AppStorage
+    /// each call — cheap (single decode) and avoids stale snapshots when the
+    /// editor mutates the table.
+    private var customButtonDefs: [CustomButton] {
+        CustomButtonStore.decode(customButtonsJSON)
     }
 
-    /// One row item in the slash-command strip — either a single button or a
-    /// collapsed `/x…` menu that expands on tap to its members.
-    enum SlashRowItem: Identifiable {
-        case button(QuickButton)
-        case group(letter: Character, buttons: [QuickButton])
+    /// The user's slot list with one-shot CSV→JSON migration handled in
+    /// `.onAppear`. Custom slots whose definition was deleted out from
+    /// under them are filtered out so the row doesn't render orphan pills.
+    private var effectiveQuickSlots: [QuickSlot] {
+        let raw = QuickSlotStore.decode(quickSlotsJSON)
+        let validIds = Set(customButtonDefs.map(\.id))
+        return raw.filter { slot in
+            if case .custom(let id) = slot { return validIds.contains(id) }
+            return true
+        }
+    }
+
+    /// First letter after the leading "/" of a slash command (e.g. "c" for
+    /// "/clear"). nil for non-slash entries or the bare "/".
+    private func slashLetter(ofText text: String) -> Character? {
+        guard text.count >= 2, text.first == "/" else { return nil }
+        return text[text.index(after: text.startIndex)].lowercased().first
+    }
+
+    /// "/foo" prefix string for a built-in's slash command, or nil for
+    /// non-slash. Wraps the QuickButton-specific check.
+    private func slashLetter(of button: QuickButton) -> Character? {
+        guard button.isSlashCommand, button != .slash else { return nil }
+        return slashLetter(ofText: button.displayName)
+    }
+
+    /// First letter of a custom button's slash payload. nil if it's not a
+    /// slash payload (raw text / keystroke customs don't get grouped).
+    private func slashLetter(of custom: CustomButton) -> Character? {
+        if case .slash(let text, _) = custom.payload {
+            return slashLetter(ofText: text)
+        }
+        return nil
+    }
+
+    /// Member of a "/x…" group menu — either a built-in or a custom button.
+    /// Identifiable so the Menu's ForEach has stable identity even when a
+    /// group mixes the two kinds.
+    enum SlashGroupMember: Identifiable {
+        case builtin(QuickButton)
+        case custom(CustomButton)
 
         var id: String {
             switch self {
-            case .button(let b): return "btn-\(b.rawValue)"
-            case .group(let l, _): return "grp-\(l)"
+            case .builtin(let b): return "b:\(b.rawValue)"
+            case .custom(let c): return "c:\(c.id.uuidString)"
+            }
+        }
+
+        var displayName: String {
+            switch self {
+            case .builtin(let b): return b.displayName
+            case .custom(let c): return c.label
             }
         }
     }
 
-    /// Group slash-command buttons by their first letter so multi-member
-    /// letters (e.g. /c → /caveman, /clear, /compact, /commit-push-pr) collapse
-    /// into a single "/c…" pill that opens a native iOS Menu on tap. Solo
-    /// letters and non-slash entries (bare /) stay as direct
-    /// buttons. Order preserved from the input array; only the first member
-    /// of a multi-letter group emits its menu pill.
-    private func slashRowItems(_ slash: [QuickButton]) -> [SlashRowItem] {
-        var lettersWithMembers: [Character: [QuickButton]] = [:]
-        for btn in slash {
-            if let key = slashLetter(of: btn) {
-                lettersWithMembers[key, default: []].append(btn)
+    /// One renderable item in the slot row. Spacers carry their UUID so
+    /// SwiftUI keeps stable identity when the user has multiple in a row.
+    enum RowItem: Identifiable {
+        case builtinButton(QuickButton)
+        case customButton(CustomButton)
+        case spacer(width: CGFloat, uid: UUID)
+        case slashGroup(letter: Character, members: [SlashGroupMember])
+
+        var id: String {
+            switch self {
+            case .builtinButton(let b): return "b:\(b.rawValue)"
+            case .customButton(let c): return "c:\(c.id.uuidString)"
+            case .spacer(_, let uid): return "s:\(uid.uuidString)"
+            case .slashGroup(let l, _): return "g:\(l)"
             }
         }
-        var items: [SlashRowItem] = []
-        var emitted = Set<Character>()
-        for btn in slash {
-            if let key = slashLetter(of: btn), let members = lettersWithMembers[key], members.count > 1 {
-                if emitted.insert(key).inserted {
-                    items.append(.group(letter: key, buttons: members))
+    }
+
+    /// Walk the slot list and produce a render plan. Slash builtins and
+    /// custom-slash buttons that share a first letter collapse into a single
+    /// `.slashGroup` so the row stays compact when the user has many. Order
+    /// preserved; only the first member of a multi-member letter emits the
+    /// group pill.
+    private func rowItems(_ slots: [QuickSlot], defs: [CustomButton]) -> [RowItem] {
+        let defsById = Dictionary(uniqueKeysWithValues: defs.map { ($0.id, $0) })
+
+        // Pre-pass: count slash-letter occurrences across builtins + customs
+        // visible in this slot list, so we know which letters need grouping.
+        var letterCount: [Character: Int] = [:]
+        for slot in slots {
+            switch slot {
+            case .builtin(let b):
+                if let key = slashLetter(of: b) { letterCount[key, default: 0] += 1 }
+            case .custom(let id):
+                if let c = defsById[id], let key = slashLetter(of: c) {
+                    letterCount[key, default: 0] += 1
                 }
-            } else {
-                items.append(.button(btn))
+            case .spacer:
+                break
+            }
+        }
+
+        // Collect group members in slot-order so menu order matches the
+        // user's row order.
+        var members: [Character: [SlashGroupMember]] = [:]
+        for slot in slots {
+            switch slot {
+            case .builtin(let b):
+                if let key = slashLetter(of: b), (letterCount[key] ?? 0) > 1 {
+                    members[key, default: []].append(.builtin(b))
+                }
+            case .custom(let id):
+                if let c = defsById[id], let key = slashLetter(of: c), (letterCount[key] ?? 0) > 1 {
+                    members[key, default: []].append(.custom(c))
+                }
+            case .spacer:
+                break
+            }
+        }
+
+        var items: [RowItem] = []
+        var emitted = Set<Character>()
+        for slot in slots {
+            switch slot {
+            case .spacer(let uid):
+                items.append(.spacer(width: 12, uid: uid))
+            case .builtin(let b):
+                if let key = slashLetter(of: b), let group = members[key], group.count > 1 {
+                    if emitted.insert(key).inserted {
+                        items.append(.slashGroup(letter: key, members: group))
+                    }
+                } else {
+                    items.append(.builtinButton(b))
+                }
+            case .custom(let id):
+                guard let c = defsById[id] else { continue }
+                if let key = slashLetter(of: c), let group = members[key], group.count > 1 {
+                    if emitted.insert(key).inserted {
+                        items.append(.slashGroup(letter: key, members: group))
+                    }
+                } else {
+                    items.append(.customButton(c))
+                }
             }
         }
         return items
@@ -2775,13 +2870,16 @@ struct MainiOSView: View {
     /// around it (system handles edge clipping + the dismiss-on-outside-tap),
     /// so the keyboard stays tidy until the user actually drills in.
     @ViewBuilder
-    private func slashGroupMenuButton(letter: Character, buttons: [QuickButton]) -> some View {
+    private func slashGroupMenuButton(letter: Character, members: [SlashGroupMember]) -> some View {
         Menu {
-            ForEach(buttons) { btn in
+            ForEach(members) { member in
                 Button {
-                    fireQuickButton(btn)
+                    switch member {
+                    case .builtin(let b): fireQuickButton(b)
+                    case .custom(let c): fireCustomButton(c)
+                    }
                 } label: {
-                    Text(btn.displayName)
+                    Text(member.displayName)
                 }
             }
         } label: {
@@ -2799,18 +2897,89 @@ struct MainiOSView: View {
         .disabled(selectedWindowId == nil)
     }
 
-    /// Render a slash-command strip with letter grouping applied. Use this in
-    /// place of `ForEach(slash) { quickActionButton($0) }`.
+    /// Render the full slot row — built-ins, customs, spacers, and grouped
+    /// `/x…` menus — in the user's chosen order.
     @ViewBuilder
-    private func slashRowView(_ slash: [QuickButton]) -> some View {
-        ForEach(slashRowItems(slash)) { item in
+    private func slotRowView(_ slots: [QuickSlot]) -> some View {
+        let items = rowItems(slots, defs: customButtonDefs)
+        ForEach(items) { item in
             switch item {
-            case .button(let btn):
-                quickActionButton(btn)
-            case .group(let letter, let buttons):
-                slashGroupMenuButton(letter: letter, buttons: buttons)
+            case .builtinButton(let b):
+                quickActionButton(b)
+            case .customButton(let c):
+                customQuickButton(c)
+            case .spacer(let w, _):
+                Spacer().frame(width: w)
+            case .slashGroup(let letter, let members):
+                slashGroupMenuButton(letter: letter, members: members)
             }
         }
+    }
+
+    /// Wire-side dispatch for a custom button. Mirrors `fireQuickButton` so
+    /// image-flush + auto-submit semantics stay identical between built-ins
+    /// and customs.
+    private func fireCustomButton(_ btn: CustomButton) {
+        guard let wid = selectedWindowId else { return }
+        switch btn.payload {
+        case .slash(let text, let auto):
+            sendCustomText(text, autoSubmit: auto, windowId: wid)
+        case .rawText(let text, let auto):
+            sendCustomText(text, autoSubmit: auto, windowId: wid)
+        case .keystroke(let action):
+            if action == "press_return" {
+                sendPendingImageIfNeeded(windowId: wid) { [client] in
+                    client.send(QuickActionMessage(windowId: wid, action: action))
+                }
+            } else {
+                client.send(QuickActionMessage(windowId: wid, action: action))
+            }
+        }
+    }
+
+    /// Shared text-send helper for custom slash + raw-text payloads. Auto-
+    /// submitting payloads flush the pending image first so the Mac
+    /// processes attachments before the prompt — same race rule as the
+    /// built-in slash buttons.
+    private func sendCustomText(_ text: String, autoSubmit: Bool, windowId wid: String) {
+        if autoSubmit {
+            sendPendingImageIfNeeded(windowId: wid) { [client] in
+                client.send(SendTextMessage(windowId: wid, text: text, pressReturn: autoSubmit))
+            }
+        } else {
+            client.send(SendTextMessage(windowId: wid, text: text, pressReturn: autoSubmit))
+        }
+    }
+
+    /// Pill rendering for a custom button. Uses the same outer chrome as
+    /// `quickActionButton` so customs visually match built-ins.
+    @ViewBuilder
+    private func customQuickButton(_ btn: CustomButton) -> some View {
+        Button {
+            fireCustomButton(btn)
+        } label: {
+            Group {
+                if let symbol = btn.systemImage, !symbol.isEmpty {
+                    Image(systemName: symbol)
+                        .font(.system(size: 13, weight: .semibold))
+                        .frame(width: 16, height: 16)
+                        .id("custom-icon-\(btn.id.uuidString)-\(symbol)")
+                        .accessibilityLabel(btn.label)
+                } else {
+                    Text(btn.label)
+                        .font(.system(size: 9, weight: .semibold, design: .monospaced))
+                        .lineLimit(1)
+                        .minimumScaleFactor(0.55)
+                }
+            }
+            .foregroundStyle(.white.opacity(selectedWindowId != nil ? 0.9 : 0.35))
+            .padding(.horizontal, 4)
+            .padding(.vertical, 5)
+            .frame(minWidth: 20)
+            .background(Color.white.opacity(0.15))
+            .clipShape(RoundedRectangle(cornerRadius: 5))
+        }
+        .disabled(selectedWindowId == nil)
     }
 
     @ViewBuilder
@@ -3630,6 +3799,207 @@ enum QuickButton: String, CaseIterable, Identifiable {
     }
 }
 
+// MARK: - Custom Buttons + Slot Ordering
+
+/// Action a user-defined button performs when tapped. Mirrors the three
+/// `QuickButton.Action` shapes so render + send code can route customs
+/// through the same `fireQuickButton`-style path.
+enum CustomPayload: Hashable {
+    /// Send "/foo[ ]" — autoSubmit controls whether to press Return after.
+    /// Slash commands like /clear / /compact auto-submit; /plan / /btw
+    /// don't (they take a follow-up argument).
+    case slash(text: String, autoSubmit: Bool)
+    /// Send arbitrary text (no leading slash). autoSubmit toggles Return.
+    case rawText(text: String, autoSubmit: Bool)
+    /// Send a `quick_action` to the Mac (press_y / press_n / press_escape /
+    /// press_ctrl_c / press_ctrl_d / press_tab / press_backspace /
+    /// clear_input / press_shift_tab).
+    case keystroke(action: String)
+}
+
+// Hand-rolled Codable for the same reason as QuickSlot — synthesis fails
+// under our build settings. Wire format: `kind` discriminator + payload
+// fields. `kind` strings are persisted, don't rename without a migration.
+extension CustomPayload: Codable {
+    private enum CodingKeys: String, CodingKey { case kind, text, autoSubmit, action }
+
+    init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        let kind = try c.decode(String.self, forKey: .kind)
+        switch kind {
+        case "slash":
+            self = .slash(
+                text: try c.decode(String.self, forKey: .text),
+                autoSubmit: try c.decode(Bool.self, forKey: .autoSubmit)
+            )
+        case "rawText":
+            self = .rawText(
+                text: try c.decode(String.self, forKey: .text),
+                autoSubmit: try c.decode(Bool.self, forKey: .autoSubmit)
+            )
+        case "keystroke":
+            self = .keystroke(action: try c.decode(String.self, forKey: .action))
+        default:
+            throw DecodingError.dataCorruptedError(
+                forKey: .kind, in: c,
+                debugDescription: "Unknown CustomPayload kind: \(kind)"
+            )
+        }
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var c = encoder.container(keyedBy: CodingKeys.self)
+        switch self {
+        case .slash(let text, let auto):
+            try c.encode("slash", forKey: .kind)
+            try c.encode(text, forKey: .text)
+            try c.encode(auto, forKey: .autoSubmit)
+        case .rawText(let text, let auto):
+            try c.encode("rawText", forKey: .kind)
+            try c.encode(text, forKey: .text)
+            try c.encode(auto, forKey: .autoSubmit)
+        case .keystroke(let action):
+            try c.encode("keystroke", forKey: .kind)
+            try c.encode(action, forKey: .action)
+        }
+    }
+}
+
+/// User-defined button. Persisted as JSON in `customButtonsJSON` and
+/// referenced from `QuickSlot.custom(id)` so the slot list and the
+/// definitions table stay independent (re-ordering doesn't mutate
+/// definitions; deleting from definitions removes any slots pointing at
+/// that id at next render).
+struct CustomButton: Codable, Hashable, Identifiable {
+    let id: UUID
+    var label: String
+    /// Optional SF Symbol name. Empty / unknown falls back to text label.
+    var systemImage: String?
+    var payload: CustomPayload
+}
+
+/// One entry in the user's quick-button row. The row renders these in
+/// declaration order (no auto-clustering — the user controls position by
+/// inserting `.spacer` slots, Apple-toolbar-style).
+enum QuickSlot: Hashable, Identifiable {
+    case builtin(QuickButton)
+    case custom(UUID)
+    /// Fixed-width gap between adjacent slots. Multiple spacers in a row
+    /// stack their widths. Carries a UUID so SwiftUI lists can identify
+    /// each spacer separately when there's more than one.
+    case spacer(UUID)
+
+    var id: String {
+        switch self {
+        case .builtin(let b): return "b:\(b.rawValue)"
+        case .custom(let uid): return "c:\(uid.uuidString)"
+        case .spacer(let uid): return "s:\(uid.uuidString)"
+        }
+    }
+}
+
+// Codable hand-rolled — Swift's automatic synthesis chokes on this enum
+// shape under our build settings. Stable wire format: `kind` discriminator
+// + a value field per case. `kind` strings are part of the persistence
+// format — don't rename without a migration.
+extension QuickSlot: Codable {
+    private enum CodingKeys: String, CodingKey { case kind, button, customID, spacerID }
+
+    init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        let kind = try c.decode(String.self, forKey: .kind)
+        switch kind {
+        case "builtin":
+            let raw = try c.decode(String.self, forKey: .button)
+            guard let button = QuickButton(rawValue: raw) else {
+                throw DecodingError.dataCorruptedError(
+                    forKey: .button, in: c,
+                    debugDescription: "Unknown QuickButton raw value: \(raw)"
+                )
+            }
+            self = .builtin(button)
+        case "custom":
+            self = .custom(try c.decode(UUID.self, forKey: .customID))
+        case "spacer":
+            self = .spacer(try c.decode(UUID.self, forKey: .spacerID))
+        default:
+            throw DecodingError.dataCorruptedError(
+                forKey: .kind, in: c,
+                debugDescription: "Unknown QuickSlot kind: \(kind)"
+            )
+        }
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var c = encoder.container(keyedBy: CodingKeys.self)
+        switch self {
+        case .builtin(let b):
+            try c.encode("builtin", forKey: .kind)
+            try c.encode(b.rawValue, forKey: .button)
+        case .custom(let id):
+            try c.encode("custom", forKey: .kind)
+            try c.encode(id, forKey: .customID)
+        case .spacer(let id):
+            try c.encode("spacer", forKey: .kind)
+            try c.encode(id, forKey: .spacerID)
+        }
+    }
+}
+
+/// Encode/decode + legacy-CSV migration for the slot list. Kept as a
+/// caseless enum (namespace) so the helpers don't accidentally get
+/// instantiated.
+enum QuickSlotStore {
+    static func decode(_ raw: String) -> [QuickSlot] {
+        guard let data = raw.data(using: .utf8),
+              let slots = try? JSONDecoder().decode([QuickSlot].self, from: data)
+        else { return [] }
+        return slots
+    }
+
+    static func encode(_ slots: [QuickSlot]) -> String {
+        guard let data = try? JSONEncoder().encode(slots),
+              let str = String(data: data, encoding: .utf8)
+        else { return "[]" }
+        return str
+    }
+
+    /// Migrate the legacy CSV `enabledQuickButtons` representation to the
+    /// new ordered slot list. Inserts a `.spacer` whenever the category
+    /// changes between adjacent built-ins, so the migrated row visually
+    /// matches the old auto-cluster layout (slash | answers | keystrokes).
+    static func migrate(fromCSV csv: String) -> [QuickSlot] {
+        let buttons = QuickButton.decode(csv)
+        var slots: [QuickSlot] = []
+        var lastCategory: QuickButton.Category?
+        for btn in buttons {
+            if let last = lastCategory, last != btn.category {
+                slots.append(.spacer(UUID()))
+            }
+            slots.append(.builtin(btn))
+            lastCategory = btn.category
+        }
+        return slots
+    }
+}
+
+/// Encode/decode the custom-button definitions table.
+enum CustomButtonStore {
+    static func decode(_ raw: String) -> [CustomButton] {
+        guard let data = raw.data(using: .utf8),
+              let buttons = try? JSONDecoder().decode([CustomButton].self, from: data)
+        else { return [] }
+        return buttons
+    }
+
+    static func encode(_ buttons: [CustomButton]) -> String {
+        guard let data = try? JSONEncoder().encode(buttons),
+              let str = String(data: data, encoding: .utf8)
+        else { return "[]" }
+        return str
+    }
+}
+
 // MARK: - Settings Sheet
 
 extension Notification.Name {
@@ -3729,7 +4099,7 @@ struct SettingsSheet: View {
                         HStack {
                             Text("Quick Buttons")
                             Spacer()
-                            Text("\(QuickButton.decode(enabledQuickButtonsRaw).count) enabled")
+                            Text(quickButtonsSummary)
                                 .foregroundStyle(.secondary)
                         }
                     }
@@ -3877,6 +4247,17 @@ struct SettingsSheet: View {
         return "On"
     }
 
+    /// Compact summary shown next to the Quick Buttons NavigationLink. Slot
+    /// count covers built-ins + customs + spacers, which is the size of the
+    /// rendered row — what the user actually cares about.
+    fileprivate var quickButtonsSummary: String {
+        let slots = QuickSlotStore.decode(
+            UserDefaults.standard.string(forKey: "quickSlotsJSON") ?? ""
+        )
+        let count = slots.count
+        return "\(count) item\(count == 1 ? "" : "s")"
+    }
+
 }
 
 /// Notifications detail page — push toggles + Quiet Hours window. Pushed
@@ -4015,62 +4396,383 @@ struct MainRowButtonsSheet: View {
     }
 }
 
+/// Apple-toolbar-style editor for the quick-button row. Slots render in
+/// user-controlled order; the "Add" toolbar menu inserts built-ins,
+/// custom buttons, or fixed-width spacers. Drag to reorder; swipe to
+/// delete. The legacy CSV `enabledQuickButtons` is kept in sync on every
+/// edit so a downgrade-and-restart still reads a sensible row.
 struct QuickButtonsSheet: View {
     @Binding var enabledQuickButtonsRaw: String
+    @AppStorage("quickSlotsJSON") private var quickSlotsJSON: String = ""
+    @AppStorage("customButtonsJSON") private var customButtonsJSON: String = "[]"
+
+    @State private var editingCustomID: UUID?
+    @State private var addingCustom: Bool = false
+
+    private var slots: [QuickSlot] { QuickSlotStore.decode(quickSlotsJSON) }
+    private var customs: [CustomButton] { CustomButtonStore.decode(customButtonsJSON) }
+    private var customsByID: [UUID: CustomButton] {
+        Dictionary(uniqueKeysWithValues: customs.map { ($0.id, $0) })
+    }
 
     var body: some View {
         List {
             Section {
-                let columns = [GridItem(.adaptive(minimum: 100, maximum: 180), spacing: 6)]
-                LazyVGrid(columns: columns, alignment: .leading, spacing: 6) {
-                    ForEach(QuickButton.allCases) { button in
-                        chip(button)
+                if slots.isEmpty {
+                    Text("No buttons yet. Tap + to add one.")
+                        .foregroundStyle(.secondary)
+                        .font(.system(size: 13))
+                } else {
+                    ForEach(slots) { slot in
+                        slotRow(slot)
                     }
+                    .onMove(perform: moveSlots)
+                    .onDelete(perform: deleteSlots)
                 }
-                .padding(.vertical, 4)
+            } header: {
+                Text("Row Order")
             } footer: {
-                Text("Tap a chip to toggle it on/off. Enabled buttons show up in the row above the keyboard.")
+                Text("Drag the handle to reorder. Swipe to remove. Spacers add fixed gaps between buttons.")
+            }
+
+            if !customs.isEmpty {
+                Section {
+                    ForEach(customs) { c in
+                        Button {
+                            editingCustomID = c.id
+                        } label: {
+                            HStack {
+                                if let sym = c.systemImage, !sym.isEmpty {
+                                    Image(systemName: sym)
+                                        .frame(width: 22)
+                                        .foregroundStyle(.secondary)
+                                }
+                                VStack(alignment: .leading, spacing: 2) {
+                                    Text(c.label).foregroundStyle(.primary)
+                                    Text(payloadSummary(c.payload))
+                                        .font(.system(size: 11))
+                                        .foregroundStyle(.secondary)
+                                        .lineLimit(1)
+                                }
+                                Spacer()
+                                Image(systemName: "chevron.right")
+                                    .font(.system(size: 11, weight: .semibold))
+                                    .foregroundStyle(.tertiary)
+                            }
+                        }
+                        .buttonStyle(.plain)
+                    }
+                    .onDelete(perform: deleteCustomDefs)
+                } header: {
+                    Text("Custom Buttons")
+                } footer: {
+                    Text("Tap to edit. Deleting here removes it from the row too.")
+                }
             }
         }
         .listStyle(.insetGrouped)
         .navigationTitle("Quick Buttons")
         .navigationBarTitleDisplayMode(.inline)
+        .toolbar {
+            ToolbarItem(placement: .topBarTrailing) {
+                EditButton()
+            }
+            ToolbarItem(placement: .topBarTrailing) {
+                Menu {
+                    Section("Add Built-in") {
+                        ForEach(QuickButton.allCases) { btn in
+                            Button {
+                                addBuiltin(btn)
+                            } label: {
+                                if let sym = btn.systemImage {
+                                    Label(btn.displayName, systemImage: sym)
+                                } else {
+                                    Text(btn.displayName)
+                                }
+                            }
+                        }
+                    }
+                    Section {
+                        Button {
+                            addingCustom = true
+                        } label: {
+                            Label("Custom Button…", systemImage: "plus.square.dashed")
+                        }
+                        Button {
+                            addSpacer()
+                        } label: {
+                            Label("Spacer", systemImage: "arrow.left.and.right")
+                        }
+                    }
+                } label: {
+                    Image(systemName: "plus")
+                }
+            }
+        }
+        .sheet(isPresented: $addingCustom) {
+            CustomButtonForm(
+                initial: nil,
+                onSave: { newButton in
+                    var defs = customs
+                    defs.append(newButton)
+                    customButtonsJSON = CustomButtonStore.encode(defs)
+                    var s = slots
+                    s.append(.custom(newButton.id))
+                    persistSlots(s)
+                }
+            )
+        }
+        .sheet(item: Binding(
+            get: { editingCustomID.flatMap { customsByID[$0] } },
+            set: { editingCustomID = $0?.id }
+        )) { existing in
+            CustomButtonForm(
+                initial: existing,
+                onSave: { updated in
+                    var defs = customs
+                    if let idx = defs.firstIndex(where: { $0.id == updated.id }) {
+                        defs[idx] = updated
+                    }
+                    customButtonsJSON = CustomButtonStore.encode(defs)
+                }
+            )
+        }
     }
 
     @ViewBuilder
-    private func chip(_ button: QuickButton) -> some View {
-        let isOn = QuickButton.decode(enabledQuickButtonsRaw).contains(button)
-        Button {
-            toggle(button)
-        } label: {
-            HStack(spacing: 4) {
-                if let icon = button.systemImage {
-                    Image(systemName: icon)
-                        .font(.system(size: 10, weight: .medium))
+    private func slotRow(_ slot: QuickSlot) -> some View {
+        switch slot {
+        case .builtin(let b):
+            HStack(spacing: 10) {
+                if let sym = b.systemImage {
+                    Image(systemName: sym)
+                        .frame(width: 22)
+                        .foregroundStyle(.secondary)
+                } else {
+                    Text(b.label)
+                        .font(.system(size: 13, weight: .semibold, design: .monospaced))
+                        .frame(width: 22, alignment: .leading)
+                        .foregroundStyle(.secondary)
                 }
-                Text(button.displayName)
-                    .font(.system(size: 12, weight: .medium))
-                    .lineLimit(1)
+                Text(b.displayName)
+                Spacer()
+                Text("Built-in").font(.caption).foregroundStyle(.tertiary)
             }
-            .frame(maxWidth: .infinity)
-            .padding(.horizontal, 10)
-            .padding(.vertical, 8)
-            .foregroundStyle(isOn ? .white : .secondary)
-            .background(isOn ? Color.accentColor : Color.secondary.opacity(0.15))
-            .clipShape(RoundedRectangle(cornerRadius: 8))
+        case .custom(let id):
+            let def = customsByID[id]
+            HStack(spacing: 10) {
+                Image(systemName: def?.systemImage?.isEmpty == false ? def!.systemImage! : "person.crop.circle")
+                    .frame(width: 22)
+                    .foregroundStyle(.secondary)
+                Text(def?.label ?? "Custom (deleted)")
+                Spacer()
+                Text("Custom").font(.caption).foregroundStyle(.tertiary)
+            }
+        case .spacer:
+            HStack {
+                Image(systemName: "arrow.left.and.right")
+                    .frame(width: 22)
+                    .foregroundStyle(.secondary)
+                Text("— Spacer —")
+                    .foregroundStyle(.secondary)
+                Spacer()
+            }
         }
-        .buttonStyle(.plain)
     }
 
-    private func toggle(_ button: QuickButton) {
-        var current = QuickButton.decode(enabledQuickButtonsRaw)
-        if current.contains(button) {
-            current.removeAll { $0 == button }
-        } else {
-            // Canonical order keeps the row stable regardless of toggle sequence.
-            current = QuickButton.allCases.filter { current.contains($0) || $0 == button }
+    private func payloadSummary(_ p: CustomPayload) -> String {
+        switch p {
+        case .slash(let t, let a): return "\(t)\(a ? " ⏎" : "")"
+        case .rawText(let t, let a): return "\"\(t)\"\(a ? " ⏎" : "")"
+        case .keystroke(let action): return action
         }
-        enabledQuickButtonsRaw = QuickButton.encode(current)
+    }
+
+    private func moveSlots(from source: IndexSet, to destination: Int) {
+        var s = slots
+        s.move(fromOffsets: source, toOffset: destination)
+        persistSlots(s)
+    }
+
+    private func deleteSlots(at offsets: IndexSet) {
+        var s = slots
+        s.remove(atOffsets: offsets)
+        persistSlots(s)
+    }
+
+    private func deleteCustomDefs(at offsets: IndexSet) {
+        var defs = customs
+        let removedIds = offsets.map { defs[$0].id }
+        defs.remove(atOffsets: offsets)
+        customButtonsJSON = CustomButtonStore.encode(defs)
+        // Cascade-remove any slots referencing the deleted custom IDs so
+        // the row doesn't render orphan "Custom (deleted)" pills.
+        let removedSet = Set(removedIds)
+        let pruned = slots.filter { slot in
+            if case .custom(let id) = slot { return !removedSet.contains(id) }
+            return true
+        }
+        if pruned.count != slots.count {
+            persistSlots(pruned)
+        }
+    }
+
+    private func addBuiltin(_ btn: QuickButton) {
+        var s = slots
+        s.append(.builtin(btn))
+        persistSlots(s)
+    }
+
+    private func addSpacer() {
+        var s = slots
+        s.append(.spacer(UUID()))
+        persistSlots(s)
+    }
+
+    /// Persist the slot list and keep the legacy CSV in sync. The CSV is no
+    /// longer the source of truth, but PreferencesSyncService still mirrors
+    /// it to the Mac for older clients and a downgrade safety net.
+    private func persistSlots(_ s: [QuickSlot]) {
+        quickSlotsJSON = QuickSlotStore.encode(s)
+        let builtins = s.compactMap { slot -> QuickButton? in
+            if case .builtin(let b) = slot { return b }
+            return nil
+        }
+        enabledQuickButtonsRaw = QuickButton.encode(builtins)
+    }
+}
+
+/// Add/edit form for a custom button. Two-section layout: identity (label
+/// + optional SF Symbol) on top, behavior (payload type + auto-submit)
+/// below. Saves go through `onSave`; the parent owns the @AppStorage write.
+struct CustomButtonForm: View {
+    /// nil = create-new flow; non-nil = edit existing.
+    let initial: CustomButton?
+    let onSave: (CustomButton) -> Void
+    @Environment(\.dismiss) private var dismiss
+
+    @State private var label: String = ""
+    @State private var systemImage: String = ""
+    @State private var payloadKind: PayloadKind = .slash
+    @State private var text: String = ""
+    @State private var autoSubmit: Bool = true
+    @State private var keystroke: String = "press_y"
+
+    enum PayloadKind: String, CaseIterable, Identifiable {
+        case slash = "Slash"
+        case rawText = "Text"
+        case keystroke = "Keystroke"
+        var id: String { rawValue }
+    }
+
+    private static let keystrokeOptions: [(label: String, action: String)] = [
+        ("Y", "press_y"), ("N", "press_n"),
+        ("1", "press_1"), ("2", "press_2"), ("3", "press_3"),
+        ("Escape", "press_escape"),
+        ("Return", "press_return"),
+        ("Tab", "press_tab"),
+        ("Shift+Tab", "press_shift_tab"),
+        ("Backspace", "press_backspace"),
+        ("Ctrl+C", "press_ctrl_c"),
+        ("Ctrl+D", "press_ctrl_d"),
+        ("Clear input", "clear_input"),
+    ]
+
+    var body: some View {
+        NavigationStack {
+            Form {
+                Section("Label") {
+                    TextField("Shown on the button", text: $label)
+                        .autocorrectionDisabled(true)
+                        .textInputAutocapitalization(.never)
+                    TextField("SF Symbol (optional)", text: $systemImage)
+                        .autocorrectionDisabled(true)
+                        .textInputAutocapitalization(.never)
+                }
+
+                Section("Action") {
+                    Picker("Type", selection: $payloadKind) {
+                        ForEach(PayloadKind.allCases) { Text($0.rawValue).tag($0) }
+                    }
+                    .pickerStyle(.segmented)
+
+                    switch payloadKind {
+                    case .slash:
+                        TextField("/foo or /foo arg", text: $text)
+                            .autocorrectionDisabled(true)
+                            .textInputAutocapitalization(.never)
+                        Toggle("Auto-submit (press Return)", isOn: $autoSubmit)
+                    case .rawText:
+                        TextField("Text to send", text: $text)
+                        Toggle("Auto-submit (press Return)", isOn: $autoSubmit)
+                    case .keystroke:
+                        Picker("Key", selection: $keystroke) {
+                            ForEach(Self.keystrokeOptions, id: \.action) { opt in
+                                Text(opt.label).tag(opt.action)
+                            }
+                        }
+                    }
+                }
+            }
+            .navigationTitle(initial == nil ? "New Button" : "Edit Button")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Cancel") { dismiss() }
+                }
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("Save") { save() }
+                        .disabled(!isValid)
+                }
+            }
+            .onAppear { hydrate() }
+        }
+    }
+
+    private var isValid: Bool {
+        let trimmedLabel = label.trimmingCharacters(in: .whitespaces)
+        guard !trimmedLabel.isEmpty else { return false }
+        switch payloadKind {
+        case .slash:
+            return text.hasPrefix("/") && text.count >= 2
+        case .rawText:
+            return !text.isEmpty
+        case .keystroke:
+            return !keystroke.isEmpty
+        }
+    }
+
+    private func hydrate() {
+        guard let initial else { return }
+        label = initial.label
+        systemImage = initial.systemImage ?? ""
+        switch initial.payload {
+        case .slash(let t, let a):
+            payloadKind = .slash; text = t; autoSubmit = a
+        case .rawText(let t, let a):
+            payloadKind = .rawText; text = t; autoSubmit = a
+        case .keystroke(let action):
+            payloadKind = .keystroke; keystroke = action
+        }
+    }
+
+    private func save() {
+        let payload: CustomPayload
+        switch payloadKind {
+        case .slash: payload = .slash(text: text, autoSubmit: autoSubmit)
+        case .rawText: payload = .rawText(text: text, autoSubmit: autoSubmit)
+        case .keystroke: payload = .keystroke(action: keystroke)
+        }
+        let trimmed = label.trimmingCharacters(in: .whitespaces)
+        let symbol = systemImage.trimmingCharacters(in: .whitespaces)
+        let btn = CustomButton(
+            id: initial?.id ?? UUID(),
+            label: trimmed,
+            systemImage: symbol.isEmpty ? nil : symbol,
+            payload: payload
+        )
+        onSave(btn)
+        dismiss()
     }
 }
 

--- a/QuipiOS/QuipApp.swift
+++ b/QuipiOS/QuipApp.swift
@@ -3668,7 +3668,7 @@ enum QuickButton: String, CaseIterable, Identifiable {
         case .compact: return "/compact"
         case .clearContext: return "/clear"
         case .prd: return "/prd"
-        case .commitPushPr: return "/commit-push-pr"
+        case .commitPushPr: return "/commit-commands:commit-push-pr"
         case .caveman: return "/caveman"
         case .ultraReview: return "/ultrareview"
         case .yes: return "Y"
@@ -3771,7 +3771,7 @@ enum QuickButton: String, CaseIterable, Identifiable {
         // pattern as /plan and /btw.
         case .prd: return .sendText("/prd ", pressReturn: false)
         // Standalone commands — auto-submit.
-        case .commitPushPr: return .sendText("/commit-push-pr", pressReturn: true)
+        case .commitPushPr: return .sendText("/commit-commands:commit-push-pr", pressReturn: true)
         case .caveman: return .sendText("/caveman", pressReturn: true)
         case .ultraReview: return .sendText("/ultrareview", pressReturn: true)
         case .yes: return .quickAction("press_y")

--- a/QuipiOS/QuipApp.swift
+++ b/QuipiOS/QuipApp.swift
@@ -1632,12 +1632,27 @@ struct MainiOSView: View {
                             default: return "rectangle.3.group"
                             }
                         }()
-                        Image(systemName: icon)
-                            .font(.system(size: 16, weight: .semibold))
-                            .foregroundStyle(windows.count >= 2 ? colors.textPrimary : colors.textFaint)
-                            .frame(width: auxW, height: auxH)
-                            .background(colors.surface)
-                            .clipShape(RoundedRectangle(cornerRadius: 12))
+                        // ZStack with a text fallback so the button is never
+                        // blank if the SF Symbol fails to draw — which has
+                        // happened when the icon name churns mid-redraw
+                        // (cycling between rectangle.split.3x1/1x3/group).
+                        // The text sits behind the icon, hidden when the icon
+                        // renders correctly.
+                        ZStack {
+                            Text("⊞")
+                                .font(.system(size: 14, weight: .semibold))
+                            Image(systemName: icon)
+                                .font(.system(size: 16, weight: .semibold))
+                                // Stable identity per icon name forces a clean
+                                // redraw instead of a partial swap that can
+                                // leave the symbol blank.
+                                .id("arrange-\(icon)")
+                                .accessibilityLabel("Arrange windows")
+                        }
+                        .foregroundStyle(windows.count >= 2 ? colors.textPrimary : colors.textFaint)
+                        .frame(width: auxW, height: auxH)
+                        .background(colors.surface)
+                        .clipShape(RoundedRectangle(cornerRadius: 12))
                     }
                     .disabled(windows.filter(\.enabled).count < 2)
                     .simultaneousGesture(
@@ -2702,18 +2717,29 @@ struct MainiOSView: View {
                 }
             }
         } label: {
-            Group {
+            ZStack {
+                // Always render the text label as a fallback so the button is
+                // never blank — even if the SF Symbol fails to draw (which has
+                // happened intermittently when the app comes back from a Live
+                // Activity / push-driven scene transition and the SF Symbol
+                // cache hasn't repopulated yet). The Image, when present, is
+                // drawn on top and hides the text. If the Image disappears,
+                // the text becomes visible automatically.
+                Text(button.label)
+                    .font(.system(size: 9, weight: .semibold, design: .monospaced))
+                    .lineLimit(1)
+                    .minimumScaleFactor(0.55)
+
                 if let symbol = button.systemImage {
                     Image(systemName: symbol)
                         .font(.system(size: 13, weight: .semibold))
-                } else {
-                    // Single-line with auto-shrink so a row of 8-10 buttons
-                    // fits on the phone without `/compact` wrapping to two
-                    // lines mid-word.
-                    Text(button.label)
-                        .font(.system(size: 9, weight: .semibold, design: .monospaced))
-                        .lineLimit(1)
-                        .minimumScaleFactor(0.55)
+                        .frame(width: 16, height: 16)
+                        // Stable identity per symbol — without it, SwiftUI
+                        // sometimes elides the icon when the button row
+                        // re-renders mid-animation.
+                        .id("qb-icon-\(symbol)")
+                        .background(Color.white.opacity(0.15))
+                        .accessibilityLabel(button.displayName)
                 }
             }
             .foregroundStyle(.white.opacity(selectedWindowId != nil ? 0.9 : 0.35))
@@ -3360,6 +3386,7 @@ enum QuickButton: String, CaseIterable, Identifiable {
     //   Claude Code answers (Y/N and number choices),
     //   Terminal keystrokes (Esc, Ctrl-C, Ctrl-D, Tab, Backspace).
     case slash, plan, btw, compact, clearContext, prd
+    case commitPushPr, caveman, ultraReview
     case yes, no, one, two, three
     case esc, ctrlC, ctrlD, tab, backspace, clearInput
     case planMode, shiftTab
@@ -3374,6 +3401,9 @@ enum QuickButton: String, CaseIterable, Identifiable {
         case .compact: return "/compact"
         case .clearContext: return "/clear"
         case .prd: return "/prd"
+        case .commitPushPr: return "/commit-push-pr"
+        case .caveman: return "/caveman"
+        case .ultraReview: return "/ultrareview"
         case .yes: return "Y"
         case .no: return "N"
         case .one: return "1"
@@ -3400,6 +3430,11 @@ enum QuickButton: String, CaseIterable, Identifiable {
         case .compact: return "/compact"
         case .clearContext: return "/clear"
         case .prd: return "/prd"
+        // Long slash commands shortened to fit the phone button row.
+        // Settings still lists the full command.
+        case .commitPushPr: return "/ship"
+        case .caveman: return "/cave"
+        case .ultraReview: return "/ultra"
         case .yes: return "Y"
         case .no: return "N"
         case .one: return "1"
@@ -3409,6 +3444,8 @@ enum QuickButton: String, CaseIterable, Identifiable {
         case .ctrlC: return "Ctrl+C"
         case .ctrlD: return "Ctrl+D"
         case .tab: return "Tab"
+        // Icon-only buttons — the SF Symbol carries the meaning. Empty label
+        // keeps the button compact (especially planMode → just the wand).
         case .backspace: return ""
         case .clearInput: return ""
         case .planMode: return ""
@@ -3447,7 +3484,7 @@ enum QuickButton: String, CaseIterable, Identifiable {
 
     var category: Category {
         switch self {
-        case .slash, .plan, .btw, .compact, .clearContext, .prd, .planMode: return .slash
+        case .slash, .plan, .btw, .compact, .clearContext, .prd, .commitPushPr, .caveman, .ultraReview, .planMode: return .slash
         case .yes, .no, .one, .two, .three: return .answer
         case .esc, .ctrlC, .ctrlD, .tab, .backspace, .clearInput, .shiftTab: return .keystroke
         }
@@ -3469,6 +3506,10 @@ enum QuickButton: String, CaseIterable, Identifiable {
         // /prd takes a follow-up description, so don't auto-submit — same
         // pattern as /plan and /btw.
         case .prd: return .sendText("/prd ", pressReturn: false)
+        // Standalone commands — auto-submit.
+        case .commitPushPr: return .sendText("/commit-push-pr", pressReturn: true)
+        case .caveman: return .sendText("/caveman", pressReturn: true)
+        case .ultraReview: return .sendText("/ultrareview", pressReturn: true)
         case .yes: return .quickAction("press_y")
         case .no: return .quickAction("press_n")
         case .one: return .sendText("1", pressReturn: true)

--- a/QuipiOS/QuipApp.swift
+++ b/QuipiOS/QuipApp.swift
@@ -3669,7 +3669,7 @@ enum QuickButton: String, CaseIterable, Identifiable {
         case .clearContext: return "/clear"
         case .prd: return "/prd"
         case .commitPushPr: return "/commit-commands:commit-push-pr"
-        case .caveman: return "/caveman"
+        case .caveman: return "/caveman:caveman"
         case .ultraReview: return "/ultrareview"
         case .yes: return "Y"
         case .no: return "N"
@@ -3772,7 +3772,7 @@ enum QuickButton: String, CaseIterable, Identifiable {
         case .prd: return .sendText("/prd ", pressReturn: false)
         // Standalone commands — auto-submit.
         case .commitPushPr: return .sendText("/commit-commands:commit-push-pr", pressReturn: true)
-        case .caveman: return .sendText("/caveman", pressReturn: true)
+        case .caveman: return .sendText("/caveman:caveman", pressReturn: true)
         case .ultraReview: return .sendText("/ultrareview", pressReturn: true)
         case .yes: return .quickAction("press_y")
         case .no: return .quickAction("press_n")

--- a/QuipiOS/QuipApp.swift
+++ b/QuipiOS/QuipApp.swift
@@ -4067,7 +4067,30 @@ struct SettingsSheet: View {
                     Text("Auto picks image when available, falls back to text. Image and Text lock the panel to one mode so it stops flickering when the Mac's screenshot stream drops out.")
                 }
 
-                // Notifications — moved behind a NavigationLink so the main
+                // Keyboard — both keyboard-row customizers behind one
+                // section header so the Settings page reads in three
+                // logical groups: Appearance, Keyboard, Notifications.
+                Section {
+                    NavigationLink {
+                        QuickButtonsSheet(enabledQuickButtonsRaw: $enabledQuickButtonsRaw)
+                    } label: {
+                        HStack {
+                            Text("Quick Buttons")
+                            Spacer()
+                            Text(quickButtonsSummary)
+                                .foregroundStyle(.secondary)
+                        }
+                    }
+                    NavigationLink {
+                        MainRowButtonsSheet()
+                    } label: {
+                        Text("Main Row Buttons")
+                    }
+                } header: {
+                    Text("Keyboard")
+                }
+
+                // Notifications — behind a NavigationLink so the main
                 // Settings page stays scannable. Inline summary on the right
                 // gives a one-glance read on whether push is on, paused, or
                 // currently quiet without drilling in.
@@ -4086,28 +4109,8 @@ struct SettingsSheet: View {
                                 .lineLimit(1)
                         }
                     }
-                }
-
-                // Quick Buttons — moved behind a NavigationLink so the
-                // ~18-chip grid doesn't pile on at the bottom of the main
-                // Settings page. Enabled-count preview gives a one-glance
-                // read on how many are active without drilling in.
-                Section {
-                    NavigationLink {
-                        QuickButtonsSheet(enabledQuickButtonsRaw: $enabledQuickButtonsRaw)
-                    } label: {
-                        HStack {
-                            Text("Quick Buttons")
-                            Spacer()
-                            Text(quickButtonsSummary)
-                                .foregroundStyle(.secondary)
-                        }
-                    }
-                    NavigationLink {
-                        MainRowButtonsSheet()
-                    } label: {
-                        Text("Main Row Buttons")
-                    }
+                } header: {
+                    Text("Notifications")
                 }
             }
             .listStyle(.insetGrouped)
@@ -4415,8 +4418,30 @@ struct QuickButtonsSheet: View {
         Dictionary(uniqueKeysWithValues: customs.map { ($0.id, $0) })
     }
 
+    /// Set of built-in QuickButton rawValues already placed in the slot
+    /// list — used to disable duplicate adds in the "+" menu so the user
+    /// can't end up with two `Esc` pills by accident.
+    private var placedBuiltins: Set<String> {
+        Set(slots.compactMap { slot -> String? in
+            if case .builtin(let b) = slot { return b.rawValue }
+            return nil
+        })
+    }
+
     var body: some View {
         List {
+            // Live preview — shows the actual rendered row exactly as it
+            // will appear above the keyboard, on the same dark surface.
+            // Updates immediately on any reorder / add / delete because
+            // it reads the same @AppStorage the keyboard does.
+            Section {
+                rowPreview
+                    .listRowInsets(EdgeInsets(top: 8, leading: 6, bottom: 8, trailing: 6))
+                    .listRowBackground(Color.clear)
+            } header: {
+                Text("Preview")
+            }
+
             Section {
                 if slots.isEmpty {
                     Text("No buttons yet. Tap + to add one.")
@@ -4430,7 +4455,13 @@ struct QuickButtonsSheet: View {
                     .onDelete(perform: deleteSlots)
                 }
             } header: {
-                Text("Row Order")
+                HStack {
+                    Text("Row Order")
+                    Spacer()
+                    Text("\(slots.count)")
+                        .foregroundStyle(.secondary)
+                        .font(.caption)
+                }
             } footer: {
                 Text("Drag the handle to reorder. Swipe to remove. Spacers add fixed gaps between buttons.")
             }
@@ -4442,11 +4473,7 @@ struct QuickButtonsSheet: View {
                             editingCustomID = c.id
                         } label: {
                             HStack {
-                                if let sym = c.systemImage, !sym.isEmpty {
-                                    Image(systemName: sym)
-                                        .frame(width: 22)
-                                        .foregroundStyle(.secondary)
-                                }
+                                customPillPreview(c)
                                 VStack(alignment: .leading, spacing: 2) {
                                     Text(c.label).foregroundStyle(.primary)
                                     Text(payloadSummary(c.payload))
@@ -4464,7 +4491,13 @@ struct QuickButtonsSheet: View {
                     }
                     .onDelete(perform: deleteCustomDefs)
                 } header: {
-                    Text("Custom Buttons")
+                    HStack {
+                        Text("Custom Buttons")
+                        Spacer()
+                        Text("\(customs.count)")
+                            .foregroundStyle(.secondary)
+                            .font(.caption)
+                    }
                 } footer: {
                     Text("Tap to edit. Deleting here removes it from the row too.")
                 }
@@ -4478,35 +4511,7 @@ struct QuickButtonsSheet: View {
                 EditButton()
             }
             ToolbarItem(placement: .topBarTrailing) {
-                Menu {
-                    Section("Add Built-in") {
-                        ForEach(QuickButton.allCases) { btn in
-                            Button {
-                                addBuiltin(btn)
-                            } label: {
-                                if let sym = btn.systemImage {
-                                    Label(btn.displayName, systemImage: sym)
-                                } else {
-                                    Text(btn.displayName)
-                                }
-                            }
-                        }
-                    }
-                    Section {
-                        Button {
-                            addingCustom = true
-                        } label: {
-                            Label("Custom Button…", systemImage: "plus.square.dashed")
-                        }
-                        Button {
-                            addSpacer()
-                        } label: {
-                            Label("Spacer", systemImage: "arrow.left.and.right")
-                        }
-                    }
-                } label: {
-                    Image(systemName: "plus")
-                }
+                addMenu
             }
         }
         .sheet(isPresented: $addingCustom) {
@@ -4543,41 +4548,203 @@ struct QuickButtonsSheet: View {
     private func slotRow(_ slot: QuickSlot) -> some View {
         switch slot {
         case .builtin(let b):
-            HStack(spacing: 10) {
-                if let sym = b.systemImage {
-                    Image(systemName: sym)
-                        .frame(width: 22)
-                        .foregroundStyle(.secondary)
-                } else {
-                    Text(b.label)
-                        .font(.system(size: 13, weight: .semibold, design: .monospaced))
-                        .frame(width: 22, alignment: .leading)
-                        .foregroundStyle(.secondary)
+            HStack(spacing: 12) {
+                builtinPillPreview(b)
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(b.displayName)
+                    Text("Built-in")
+                        .font(.system(size: 11))
+                        .foregroundStyle(.tertiary)
                 }
-                Text(b.displayName)
                 Spacer()
-                Text("Built-in").font(.caption).foregroundStyle(.tertiary)
             }
         case .custom(let id):
-            let def = customsByID[id]
-            HStack(spacing: 10) {
-                Image(systemName: def?.systemImage?.isEmpty == false ? def!.systemImage! : "person.crop.circle")
-                    .frame(width: 22)
-                    .foregroundStyle(.secondary)
-                Text(def?.label ?? "Custom (deleted)")
-                Spacer()
-                Text("Custom").font(.caption).foregroundStyle(.tertiary)
+            if let def = customsByID[id] {
+                HStack(spacing: 12) {
+                    customPillPreview(def)
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text(def.label)
+                        Text("Custom · \(payloadSummary(def.payload))")
+                            .font(.system(size: 11))
+                            .foregroundStyle(.tertiary)
+                            .lineLimit(1)
+                    }
+                    Spacer()
+                }
+            } else {
+                HStack(spacing: 12) {
+                    Image(systemName: "questionmark.square.dashed")
+                        .frame(width: 36, height: 28)
+                        .foregroundStyle(.tertiary)
+                    Text("Custom (deleted)").foregroundStyle(.secondary)
+                    Spacer()
+                }
             }
         case .spacer:
-            HStack {
-                Image(systemName: "arrow.left.and.right")
-                    .frame(width: 22)
-                    .foregroundStyle(.secondary)
-                Text("— Spacer —")
+            HStack(spacing: 12) {
+                Rectangle()
+                    .fill(Color.secondary.opacity(0.15))
+                    .frame(width: 36, height: 28)
+                    .clipShape(RoundedRectangle(cornerRadius: 6))
+                    .overlay(
+                        Image(systemName: "arrow.left.and.right")
+                            .font(.system(size: 11, weight: .semibold))
+                            .foregroundStyle(.secondary)
+                    )
+                Text("Spacer")
                     .foregroundStyle(.secondary)
                 Spacer()
             }
         }
+    }
+
+    /// Live preview of the actual quick-button row, rendered on the dark
+    /// keyboard surface so users see exactly what they'll get without
+    /// dismissing the editor. Horizontally scrolls when the row gets long.
+    @ViewBuilder
+    private var rowPreview: some View {
+        let items = previewRowItems
+        ScrollView(.horizontal, showsIndicators: false) {
+            HStack(spacing: 3) {
+                if items.isEmpty {
+                    Text("Empty — add a button below")
+                        .font(.system(size: 11))
+                        .foregroundStyle(.white.opacity(0.5))
+                        .frame(maxWidth: .infinity, alignment: .center)
+                        .padding(.horizontal, 12)
+                } else {
+                    ForEach(items, id: \.0) { _, view in
+                        view
+                    }
+                }
+            }
+            .padding(.horizontal, 8)
+            .padding(.vertical, 8)
+            .frame(maxWidth: .infinity, minHeight: 44, alignment: .leading)
+        }
+        .background(Color.black.opacity(0.85))
+        .clipShape(RoundedRectangle(cornerRadius: 10))
+    }
+
+    /// Build the preview items as `(id, AnyView)` pairs so SwiftUI's
+    /// ForEach has stable identity even though the items are a mix of
+    /// builtin pills, custom pills, and spacers. Mirrors the same render
+    /// logic as the live keyboard row, minus the disable-when-disconnected
+    /// styling (the editor doesn't need to grey out its preview).
+    private var previewRowItems: [(String, AnyView)] {
+        var result: [(String, AnyView)] = []
+        for slot in slots {
+            switch slot {
+            case .builtin(let b):
+                result.append((slot.id, AnyView(builtinPillPreview(b))))
+            case .custom(let id):
+                if let def = customsByID[id] {
+                    result.append((slot.id, AnyView(customPillPreview(def))))
+                }
+            case .spacer:
+                result.append((slot.id, AnyView(
+                    Color.clear.frame(width: 12, height: 1)
+                )))
+            }
+        }
+        return result
+    }
+
+    /// Pill mock that matches the keyboard's `quickActionButton` chrome.
+    /// Intentionally non-interactive in the editor — just a visual proxy.
+    @ViewBuilder
+    private func builtinPillPreview(_ b: QuickButton) -> some View {
+        Group {
+            if let sym = b.systemImage {
+                Image(systemName: sym)
+                    .font(.system(size: 13, weight: .semibold))
+                    .frame(width: 16, height: 16)
+            } else {
+                Text(b.label)
+                    .font(.system(size: 9, weight: .semibold, design: .monospaced))
+                    .lineLimit(1)
+            }
+        }
+        .foregroundStyle(.white.opacity(0.9))
+        .padding(.horizontal, 4)
+        .padding(.vertical, 5)
+        .frame(minWidth: 20, minHeight: 28)
+        .background(Color.white.opacity(0.15))
+        .clipShape(RoundedRectangle(cornerRadius: 5))
+    }
+
+    @ViewBuilder
+    private func customPillPreview(_ c: CustomButton) -> some View {
+        Group {
+            if let sym = c.systemImage, !sym.isEmpty {
+                Image(systemName: sym)
+                    .font(.system(size: 13, weight: .semibold))
+                    .frame(width: 16, height: 16)
+            } else {
+                Text(c.label)
+                    .font(.system(size: 9, weight: .semibold, design: .monospaced))
+                    .lineLimit(1)
+            }
+        }
+        .foregroundStyle(.white.opacity(0.9))
+        .padding(.horizontal, 4)
+        .padding(.vertical, 5)
+        .frame(minWidth: 20, minHeight: 28)
+        .background(Color.white.opacity(0.15))
+        .clipShape(RoundedRectangle(cornerRadius: 5))
+    }
+
+    /// "+" toolbar menu, categorized so the long QuickButton list isn't a
+    /// flat scroll-of-doom. Built-ins already in the slot list are
+    /// disabled to prevent accidental duplicates.
+    @ViewBuilder
+    private var addMenu: some View {
+        Menu {
+            Section("Slash") {
+                ForEach(QuickButton.allCases.filter { $0.category == .slash }) { btn in
+                    builtinAddRow(btn)
+                }
+            }
+            Section("Answers") {
+                ForEach(QuickButton.allCases.filter { $0.category == .answer }) { btn in
+                    builtinAddRow(btn)
+                }
+            }
+            Section("Keystrokes") {
+                ForEach(QuickButton.allCases.filter { $0.category == .keystroke }) { btn in
+                    builtinAddRow(btn)
+                }
+            }
+            Section {
+                Button {
+                    addingCustom = true
+                } label: {
+                    Label("Custom Button…", systemImage: "plus.square.dashed")
+                }
+                Button {
+                    addSpacer()
+                } label: {
+                    Label("Spacer", systemImage: "arrow.left.and.right")
+                }
+            }
+        } label: {
+            Image(systemName: "plus")
+        }
+    }
+
+    @ViewBuilder
+    private func builtinAddRow(_ btn: QuickButton) -> some View {
+        let placed = placedBuiltins.contains(btn.rawValue)
+        Button {
+            addBuiltin(btn)
+        } label: {
+            if let sym = btn.systemImage {
+                Label(btn.displayName + (placed ? " · added" : ""), systemImage: sym)
+            } else {
+                Text(btn.displayName + (placed ? " · added" : ""))
+            }
+        }
+        .disabled(placed)
     }
 
     private func payloadSummary(_ p: CustomPayload) -> String {

--- a/QuipiOS/QuipApp.swift
+++ b/QuipiOS/QuipApp.swift
@@ -1756,13 +1756,14 @@ struct MainiOSView: View {
                 if !isPortrait {
                     let enabled = QuickButton.decode(enabledQuickButtonsRaw)
                     if !enabled.isEmpty {
+                        let landscapeSlash = enabled.filter { $0.isSlashCommand || $0 == .slash }
+                        let landscapeRest = enabled.filter { !($0.isSlashCommand || $0 == .slash) }
                         Spacer().frame(width: 8)
-                        ForEach(Array(enabled.enumerated()), id: \.element.id) { index, button in
-                            if index > 0, enabled[index - 1].isSlashCommand != button.isSlashCommand {
-                                Spacer().frame(width: 6)
-                            }
-                            quickActionButton(button)
+                        slashRowView(landscapeSlash)
+                        if !landscapeSlash.isEmpty, !landscapeRest.isEmpty {
+                            Spacer().frame(width: 6)
                         }
+                        ForEach(landscapeRest) { quickActionButton($0) }
                     }
                 }
             }
@@ -1779,7 +1780,7 @@ struct MainiOSView: View {
                     let numbers = enabled.filter { $0 == .one || $0 == .two || $0 == .three }
                     let keystroke = enabled.filter { $0.category == .keystroke }
                     HStack(spacing: 3) {
-                        ForEach(slash) { quickActionButton($0) }
+                        slashRowView(slash)
                         Spacer(minLength: 6)
                         ForEach(yesNo) { quickActionButton($0) }
                         // Small fixed gap between Y/N (confirmations) and
@@ -2691,55 +2692,152 @@ struct MainiOSView: View {
 
     // MARK: - Configurable Quick Buttons
 
-    @ViewBuilder
-    private func quickActionButton(_ button: QuickButton) -> some View {
-        Button {
-            guard let wid = selectedWindowId else { return }
-            switch button.action {
-            case .sendText(let text, let pressReturn):
-                // Auto-submitting text is a "submit" — flush any pending image
-                // first and defer the text send until after the image hits the
-                // wire so the Mac processes them in order.
-                if pressReturn {
-                    sendPendingImageIfNeeded(windowId: wid) { [client] in
-                        client.send(SendTextMessage(windowId: wid, text: text, pressReturn: pressReturn))
-                    }
-                } else {
+    /// Fire the wire action for a QuickButton — extracted from `quickActionButton`
+    /// so the slash-letter Menu items (which trigger from a Menu, not a Button
+    /// label) can share the same image-flush + send semantics.
+    private func fireQuickButton(_ button: QuickButton) {
+        guard let wid = selectedWindowId else { return }
+        switch button.action {
+        case .sendText(let text, let pressReturn):
+            // Auto-submitting text is a "submit" — flush any pending image
+            // first and defer the text send until after the image hits the
+            // wire so the Mac processes them in order.
+            if pressReturn {
+                sendPendingImageIfNeeded(windowId: wid) { [client] in
                     client.send(SendTextMessage(windowId: wid, text: text, pressReturn: pressReturn))
                 }
-            case .quickAction(let action):
-                if action == "press_return" {
-                    sendPendingImageIfNeeded(windowId: wid) { [client] in
-                        client.send(QuickActionMessage(windowId: wid, action: action))
-                    }
-                } else {
+            } else {
+                client.send(SendTextMessage(windowId: wid, text: text, pressReturn: pressReturn))
+            }
+        case .quickAction(let action):
+            if action == "press_return" {
+                sendPendingImageIfNeeded(windowId: wid) { [client] in
                     client.send(QuickActionMessage(windowId: wid, action: action))
+                }
+            } else {
+                client.send(QuickActionMessage(windowId: wid, action: action))
+            }
+        }
+    }
+
+    /// First letter after the leading "/" for slash-command buttons (e.g. "c"
+    /// for "/clear"). Returns nil for non-slash actions or the bare "/".
+    private func slashLetter(of button: QuickButton) -> Character? {
+        guard button.isSlashCommand, button != .slash else { return nil }
+        let s = button.displayName
+        guard s.count >= 2, s.first == "/" else { return nil }
+        return s[s.index(after: s.startIndex)].lowercased().first
+    }
+
+    /// One row item in the slash-command strip — either a single button or a
+    /// collapsed `/x…` menu that expands on tap to its members.
+    enum SlashRowItem: Identifiable {
+        case button(QuickButton)
+        case group(letter: Character, buttons: [QuickButton])
+
+        var id: String {
+            switch self {
+            case .button(let b): return "btn-\(b.rawValue)"
+            case .group(let l, _): return "grp-\(l)"
+            }
+        }
+    }
+
+    /// Group slash-command buttons by their first letter so multi-member
+    /// letters (e.g. /c → /caveman, /clear, /compact, /commit-push-pr) collapse
+    /// into a single "/c…" pill that opens a native iOS Menu on tap. Solo
+    /// letters and non-slash entries (bare /, planMode wand) stay as direct
+    /// buttons. Order preserved from the input array; only the first member
+    /// of a multi-letter group emits its menu pill.
+    private func slashRowItems(_ slash: [QuickButton]) -> [SlashRowItem] {
+        var lettersWithMembers: [Character: [QuickButton]] = [:]
+        for btn in slash {
+            if let key = slashLetter(of: btn) {
+                lettersWithMembers[key, default: []].append(btn)
+            }
+        }
+        var items: [SlashRowItem] = []
+        var emitted = Set<Character>()
+        for btn in slash {
+            if let key = slashLetter(of: btn), let members = lettersWithMembers[key], members.count > 1 {
+                if emitted.insert(key).inserted {
+                    items.append(.group(letter: key, buttons: members))
+                }
+            } else {
+                items.append(.button(btn))
+            }
+        }
+        return items
+    }
+
+    /// Pill that matches `quickActionButton`'s shape but opens an iOS Menu
+    /// when tapped. The Menu auto-positions to avoid overlapping the keys
+    /// around it (system handles edge clipping + the dismiss-on-outside-tap),
+    /// so the keyboard stays tidy until the user actually drills in.
+    @ViewBuilder
+    private func slashGroupMenuButton(letter: Character, buttons: [QuickButton]) -> some View {
+        Menu {
+            ForEach(buttons) { btn in
+                Button {
+                    fireQuickButton(btn)
+                } label: {
+                    Text(btn.displayName)
                 }
             }
         } label: {
-            ZStack {
-                // Always render the text label as a fallback so the button is
-                // never blank — even if the SF Symbol fails to draw (which has
-                // happened intermittently when the app comes back from a Live
-                // Activity / push-driven scene transition and the SF Symbol
-                // cache hasn't repopulated yet). The Image, when present, is
-                // drawn on top and hides the text. If the Image disappears,
-                // the text becomes visible automatically.
-                Text(button.label)
-                    .font(.system(size: 9, weight: .semibold, design: .monospaced))
-                    .lineLimit(1)
-                    .minimumScaleFactor(0.55)
+            Text("/\(String(letter))…")
+                .font(.system(size: 9, weight: .semibold, design: .monospaced))
+                .lineLimit(1)
+                .minimumScaleFactor(0.55)
+                .foregroundStyle(.white.opacity(selectedWindowId != nil ? 0.9 : 0.35))
+                .padding(.horizontal, 4)
+                .padding(.vertical, 5)
+                .frame(minWidth: 20)
+                .background(Color.white.opacity(0.15))
+                .clipShape(RoundedRectangle(cornerRadius: 5))
+        }
+        .disabled(selectedWindowId == nil)
+    }
 
+    /// Render a slash-command strip with letter grouping applied. Use this in
+    /// place of `ForEach(slash) { quickActionButton($0) }`.
+    @ViewBuilder
+    private func slashRowView(_ slash: [QuickButton]) -> some View {
+        ForEach(slashRowItems(slash)) { item in
+            switch item {
+            case .button(let btn):
+                quickActionButton(btn)
+            case .group(let letter, let buttons):
+                slashGroupMenuButton(letter: letter, buttons: buttons)
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func quickActionButton(_ button: QuickButton) -> some View {
+        Button {
+            fireQuickButton(button)
+        } label: {
+            // Render EITHER the symbol OR the text label, never both. A prior
+            // ZStack-with-fallback approach drew Text behind Image, but for
+            // buttons whose `label` is wider than the 16x16 icon frame
+            // (e.g. "Ctrl+C", "⌫"), the Text bled out past the icon edges
+            // and looked like a second smaller pill nested inside the outer
+            // pill — the keystroke-cluster "collision" artifact. The stable
+            // `.id` per symbol is what prevents the intermittent
+            // icon-disappearance, not the text fallback.
+            Group {
                 if let symbol = button.systemImage {
                     Image(systemName: symbol)
                         .font(.system(size: 13, weight: .semibold))
                         .frame(width: 16, height: 16)
-                        // Stable identity per symbol — without it, SwiftUI
-                        // sometimes elides the icon when the button row
-                        // re-renders mid-animation.
                         .id("qb-icon-\(symbol)")
-                        .background(Color.white.opacity(0.15))
                         .accessibilityLabel(button.displayName)
+                } else {
+                    Text(button.label)
+                        .font(.system(size: 9, weight: .semibold, design: .monospaced))
+                        .lineLimit(1)
+                        .minimumScaleFactor(0.55)
                 }
             }
             .foregroundStyle(.white.opacity(selectedWindowId != nil ? 0.9 : 0.35))
@@ -3608,44 +3706,26 @@ struct SettingsSheet: View {
                     Text("Auto picks image when available, falls back to text. Image and Text lock the panel to one mode so it stops flickering when the Mac's screenshot stream drops out.")
                 }
 
-                // Notifications — one section. Kill switch on top; the
-                // usual sub-toggles only matter if Pause All is off, so we
-                // gate them behind it to cut visual noise. Quiet Hours
-                // steppers only show when the toggle is on, same deal.
-                // Kept tight: no secondary "status" footer unless the OS
-                // hasn't granted permission — that's the one case worth
-                // surfacing because push won't work at all.
+                // Notifications — moved behind a NavigationLink so the main
+                // Settings page stays scannable. Inline summary on the right
+                // gives a one-glance read on whether push is on, paused, or
+                // currently quiet without drilling in.
                 Section {
-                    Toggle("Pause All", isOn: $pushPaused)
-                    if !pushPaused {
-                        Toggle("Banner", isOn: $pushBannerEnabled)
-                        if pushBannerEnabled {
-                            Toggle("Sound", isOn: $pushSound)
-                            Toggle("Banner When App Open", isOn: $pushForegroundBanner)
+                    NavigationLink {
+                        NotificationsSettingsSheet(
+                            client: client,
+                            pushRegistration: pushRegistration
+                        )
+                    } label: {
+                        HStack {
+                            Text("Notifications")
+                            Spacer()
+                            Text(notificationsSummary)
+                                .foregroundStyle(.secondary)
+                                .lineLimit(1)
                         }
-                        Toggle("Live Activities", isOn: $liveActivitiesEnabled)
-                        Toggle("Quiet Hours", isOn: $quietHoursEnabled)
-                        if quietHoursEnabled {
-                            Stepper("From \(formatHour(quietHoursStart))",
-                                    value: $quietHoursStart, in: 0...23)
-                            Stepper("Until \(formatHour(quietHoursEnd))",
-                                    value: $quietHoursEnd, in: 0...23)
-                        }
-                    }
-                } header: {
-                    Text("Notifications")
-                } footer: {
-                    if pushRegistration.deviceToken == nil {
-                        Text("Notification permission not granted. Reconnect or check iOS Settings → Quip.")
                     }
                 }
-                .onChange(of: pushPaused) { _, _ in sendPrefs() }
-                .onChange(of: pushBannerEnabled) { _, _ in sendPrefs() }
-                .onChange(of: pushSound) { _, _ in sendPrefs() }
-                .onChange(of: pushForegroundBanner) { _, _ in sendPrefs() }
-                .onChange(of: quietHoursEnabled) { _, _ in sendPrefs() }
-                .onChange(of: quietHoursStart) { _, _ in sendPrefs() }
-                .onChange(of: quietHoursEnd) { _, _ in sendPrefs() }
 
                 // Quick Buttons — moved behind a NavigationLink so the
                 // ~18-chip grid doesn't pile on at the bottom of the main
@@ -3793,6 +3873,118 @@ struct SettingsSheet: View {
         return "\(display) \(suffix)"
     }
 
+    /// One-line state summary shown next to the Notifications NavigationLink
+    /// on the main Settings page. Priority: Paused beats everything; then a
+    /// quiet-now flag; otherwise just "On" or "Banner off". Kept short so it
+    /// doesn't fight the disclosure chevron for row space.
+    fileprivate var notificationsSummary: String {
+        if pushPaused { return "Paused" }
+        if !pushBannerEnabled { return "Banner off" }
+        if quietHoursEnabled {
+            return "Quiet \(formatHour(quietHoursStart))–\(formatHour(quietHoursEnd))"
+        }
+        return "On"
+    }
+
+}
+
+/// Notifications detail page — push toggles + Quiet Hours window. Pushed
+/// behind a NavigationLink in `SettingsSheet` so the main settings list
+/// stays short. Reads the same @AppStorage keys (single source of truth in
+/// UserDefaults), so changes here flow back to the parent automatically.
+struct NotificationsSettingsSheet: View {
+    var client: WebSocketClient
+    var pushRegistration: PushRegistrationService
+    @AppStorage("pushPaused") private var pushPaused = false
+    @AppStorage("pushBannerEnabled") private var pushBannerEnabled = true
+    @AppStorage("pushSound") private var pushSound = true
+    @AppStorage("pushForegroundBanner") private var pushForegroundBanner = false
+    @AppStorage("pushQuietHoursEnabled") private var quietHoursEnabled = false
+    @AppStorage("pushQuietHoursStart") private var quietHoursStart = 22
+    @AppStorage("pushQuietHoursEnd") private var quietHoursEnd = 7
+    @AppStorage("liveActivitiesEnabled") private var liveActivitiesEnabled = true
+
+    var body: some View {
+        List {
+            Section {
+                Toggle("Pause All", isOn: $pushPaused)
+                if !pushPaused {
+                    Toggle("Banner", isOn: $pushBannerEnabled)
+                    if pushBannerEnabled {
+                        Toggle("Sound", isOn: $pushSound)
+                        Toggle("Banner When App Open", isOn: $pushForegroundBanner)
+                    }
+                    Toggle("Live Activities", isOn: $liveActivitiesEnabled)
+
+                    // Quiet Hours kept to two rows max:
+                    //   row 1: "Quiet Hours" toggle
+                    //   row 2: "From [pill] to [pill]" range picker (only visible
+                    //          when the toggle is on)
+                    // Compact Menu pickers replace the old pair of full-width
+                    // Steppers — those took two rows by themselves and pushed the
+                    // section unnecessarily long.
+                    Toggle("Quiet Hours", isOn: $quietHoursEnabled)
+                    if quietHoursEnabled {
+                        HStack {
+                            Text("From")
+                            Spacer()
+                            hourMenu(value: $quietHoursStart)
+                            Text("to")
+                                .foregroundStyle(.secondary)
+                            hourMenu(value: $quietHoursEnd)
+                        }
+                    }
+                }
+            } footer: {
+                if pushRegistration.deviceToken == nil {
+                    Text("Notification permission not granted. Reconnect or check iOS Settings → Quip.")
+                }
+            }
+            .onChange(of: pushPaused) { _, _ in sendPrefs() }
+            .onChange(of: pushBannerEnabled) { _, _ in sendPrefs() }
+            .onChange(of: pushSound) { _, _ in sendPrefs() }
+            .onChange(of: pushForegroundBanner) { _, _ in sendPrefs() }
+            .onChange(of: quietHoursEnabled) { _, _ in sendPrefs() }
+            .onChange(of: quietHoursStart) { _, _ in sendPrefs() }
+            .onChange(of: quietHoursEnd) { _, _ in sendPrefs() }
+        }
+        .navigationTitle("Notifications")
+        .navigationBarTitleDisplayMode(.inline)
+    }
+
+    /// Compact 24-hour Menu picker. Renders the selected hour as a small pill
+    /// (e.g. "10 PM") which expands to a 24-row scrollable menu on tap. Way
+    /// tighter than a Stepper — fits two side-by-side on one row.
+    @ViewBuilder
+    private func hourMenu(value: Binding<Int>) -> some View {
+        Menu(formatHour(value.wrappedValue)) {
+            ForEach(0..<24, id: \.self) { h in
+                Button(formatHour(h)) { value.wrappedValue = h }
+            }
+        }
+    }
+
+    private func formatHour(_ h: Int) -> String {
+        let hh = h % 24
+        let suffix = hh < 12 ? "AM" : "PM"
+        let display = hh == 0 ? 12 : (hh > 12 ? hh - 12 : hh)
+        return "\(display) \(suffix)"
+    }
+
+    private func sendPrefs() {
+        guard let token = pushRegistration.deviceToken else { return }
+        let msg = PushPreferencesMessage(
+            deviceToken: token,
+            paused: pushPaused,
+            quietHoursStart: quietHoursEnabled ? quietHoursStart : nil,
+            quietHoursEnd: quietHoursEnabled ? quietHoursEnd : nil,
+            sound: pushSound,
+            foregroundBanner: pushForegroundBanner,
+            bannerEnabled: pushBannerEnabled,
+            timeZone: TimeZone.current.identifier
+        )
+        client.send(msg)
+    }
 }
 
 /// Quick Buttons detail page — lives behind a NavigationLink in SettingsSheet

--- a/QuipiOS/QuipApp.swift
+++ b/QuipiOS/QuipApp.swift
@@ -2746,7 +2746,7 @@ struct MainiOSView: View {
     /// Group slash-command buttons by their first letter so multi-member
     /// letters (e.g. /c → /caveman, /clear, /compact, /commit-push-pr) collapse
     /// into a single "/c…" pill that opens a native iOS Menu on tap. Solo
-    /// letters and non-slash entries (bare /, planMode wand) stay as direct
+    /// letters and non-slash entries (bare /) stay as direct
     /// buttons. Order preserved from the input array; only the first member
     /// of a multi-letter group emits its menu pill.
     private func slashRowItems(_ slash: [QuickButton]) -> [SlashRowItem] {
@@ -3487,7 +3487,7 @@ enum QuickButton: String, CaseIterable, Identifiable {
     case commitPushPr, caveman, ultraReview
     case yes, no, one, two, three
     case esc, ctrlC, ctrlD, tab, backspace, clearInput
-    case planMode, shiftTab
+    case shiftTab
 
     var id: String { rawValue }
 
@@ -3513,7 +3513,6 @@ enum QuickButton: String, CaseIterable, Identifiable {
         case .tab: return "Tab"
         case .backspace: return "Backspace"
         case .clearInput: return "Clear input"
-        case .planMode: return "→Plan mode"
         case .shiftTab: return "Shift+Tab"
         }
     }
@@ -3543,10 +3542,9 @@ enum QuickButton: String, CaseIterable, Identifiable {
         case .ctrlD: return "Ctrl+D"
         case .tab: return "Tab"
         // Icon-only buttons — the SF Symbol carries the meaning. Empty label
-        // keeps the button compact (especially planMode → just the wand).
+        // keeps the button compact.
         case .backspace: return ""
         case .clearInput: return ""
-        case .planMode: return ""
         case .shiftTab: return ""
         }
     }
@@ -3559,7 +3557,6 @@ enum QuickButton: String, CaseIterable, Identifiable {
         case .ctrlD: return "eject"
         case .tab: return "arrow.right.to.line"
         case .clearInput: return "delete.left.fill"
-        case .planMode: return "wand.and.stars"
         case .shiftTab: return "arrow.left.to.line"
         default: return nil
         }
@@ -3582,7 +3579,7 @@ enum QuickButton: String, CaseIterable, Identifiable {
 
     var category: Category {
         switch self {
-        case .slash, .plan, .btw, .compact, .clearContext, .prd, .commitPushPr, .caveman, .ultraReview, .planMode: return .slash
+        case .slash, .plan, .btw, .compact, .clearContext, .prd, .commitPushPr, .caveman, .ultraReview: return .slash
         case .yes, .no, .one, .two, .three: return .answer
         case .esc, .ctrlC, .ctrlD, .tab, .backspace, .clearInput, .shiftTab: return .keystroke
         }
@@ -3619,13 +3616,7 @@ enum QuickButton: String, CaseIterable, Identifiable {
         case .tab: return .quickAction("press_tab")
         case .backspace: return .quickAction("press_backspace")
         case .clearInput: return .quickAction("clear_input")
-        // Mac side reads the detected Claude mode for the target window and
-        // sends just enough Shift+Tab presses to reach plan mode (cycle order:
-        // normal → autoAccept → plan → normal). Falls back to an ErrorMessage
-        // toast on the phone when the mode isn't yet detected.
-        case .planMode: return .quickAction("set_plan_mode")
-        // Raw Shift+Tab — manual fallback when mode auto-detect is unreliable
-        // or the user wants to step through the cycle one mode at a time.
+        // Raw Shift+Tab — cycles Claude mode (normal → autoAccept → plan).
         case .shiftTab: return .quickAction("press_shift_tab")
         }
     }

--- a/QuipiOS/QuipiOS.xcodeproj/project.pbxproj
+++ b/QuipiOS/QuipiOS.xcodeproj/project.pbxproj
@@ -13,6 +13,7 @@
 		046BFBEA924261A691A9EA3B /* PendingImagePreviewStrip.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE0BC3568ECDD8FC3E78B940 /* PendingImagePreviewStrip.swift */; };
 		0AA0F2FFEDD25846D8E8E6A0 /* AudioRingBuffer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 30CED6C2881B9B0070767205 /* AudioRingBuffer.swift */; };
 		0DB71EDB9501F21F1248DF62 /* QuipMacPermsActivityWidget.swift in Sources */ = {isa = PBXBuildFile; fileRef = 46181BEC707D4C04671D336E /* QuipMacPermsActivityWidget.swift */; };
+		192A0DA56B5881A451A18799 /* RecognizerRolloverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B0C4B6E9EA1F79748808978 /* RecognizerRolloverTests.swift */; };
 		1FED4AB0761613E80C3FAC9D /* SpeechServicePathSelectionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47C70308C62E57B9CBBEFF9E /* SpeechServicePathSelectionTests.swift */; };
 		20FE94C556B5D03097FB0030 /* PreferencesSyncService.swift in Sources */ = {isa = PBXBuildFile; fileRef = D94647DAF2E9DB9470CB5FF5 /* PreferencesSyncService.swift */; };
 		216CB65B0E4953EF7B3C45BA /* LiveActivityService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 731E1A072569A16DBA76D9EB /* LiveActivityService.swift */; };
@@ -24,11 +25,10 @@
 		2F94D38C500B41994A45596A /* ImageUploadMessageTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DED5CFC890EBB97FEDDAAFC /* ImageUploadMessageTests.swift */; };
 		2FDDC840F5A589B81D2517D0 /* MessageProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE4E6BADD636034CE8C5EC9A /* MessageProtocol.swift */; };
 		2FE851D3B7E5A263C2E1A06F /* SilentModeDetector.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDFEC177041E6CF5C96C7D88 /* SilentModeDetector.swift */; };
+		35848956152082FFE9094000 /* PhoneLayoutChooserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0BD4C0C02F1EAFBEEDC5EA1D /* PhoneLayoutChooserTests.swift */; };
 		390A246B5D13F798E9B55E7B /* ImageRecompressor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D6ED80C8277F668CC0B273C /* ImageRecompressor.swift */; };
 		3C69E42DAC8E6515F9BC3F03 /* WindowManagerSessionIdTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 764505DC63C7C214558A63CC /* WindowManagerSessionIdTests.swift */; };
 		413005C731BCDCED5438E47F /* InlineTerminalContentBranchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD67F0481CA1F97EEB2F5D7C /* InlineTerminalContentBranchTests.swift */; };
-		BAE1BE644A1C4697BEE9DB46 /* RecognizerRolloverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5803A385303C46EA4D51BE3 /* RecognizerRolloverTests.swift */; };
-		3EA86BE677664FD4A49B813D /* PhoneLayoutChooserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 859196B75583406E935B86A7 /* PhoneLayoutChooserTests.swift */; };
 		46B88647F52CB2FD8C378212 /* dictation-vocab.txt in Resources */ = {isa = PBXBuildFile; fileRef = 38403BB3D3EAD614680767A6 /* dictation-vocab.txt */; };
 		48F28455B8142325D6833C25 /* QuipTheme.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE693F49CD672CFD1507FDC6 /* QuipTheme.swift */; };
 		4D0689B3D9653512F27A322D /* BonjourBrowser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9EB84DC38B2B261AB78D9B78 /* BonjourBrowser.swift */; };
@@ -52,6 +52,7 @@
 		A795C27D5F398A26647E2B49 /* SeamStitcherTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B827C2D030F43E7C9485615 /* SeamStitcherTests.swift */; };
 		A977CCC72BA863A04F17FB77 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 07BAAAC4E0E8051B6FF2664E /* Assets.xcassets */; };
 		AC12BD221896070181F785DC /* QuipLiveActivityWidget.swift in Sources */ = {isa = PBXBuildFile; fileRef = 109D3594919D4EF54DE97C72 /* QuipLiveActivityWidget.swift */; };
+		B712CA6389A8643DAA92C4FE /* CertPins.json in Resources */ = {isa = PBXBuildFile; fileRef = 50991F62509F0EBB3C8037B9 /* CertPins.json */; };
 		B74D4BBBD664959095BE58DE /* ConnectionStatusBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = F09BCC5DEEA227B256C96191 /* ConnectionStatusBar.swift */; };
 		B86CDE99611F63E70CB7C7A3 /* RemoteLayoutView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AA3AAD9A42CCC12C55FB55F /* RemoteLayoutView.swift */; };
 		BC0AAA34114426CFF2BEEB74 /* ArrangeLayoutMappingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDEE82AF4A4EEBCF4A0DED50 /* ArrangeLayoutMappingTests.swift */; };
@@ -63,6 +64,7 @@
 		D90497A715C2D1FEBC04B532 /* LinkifiedTerminalContentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6D5159A24459D33F4AE547B /* LinkifiedTerminalContentTests.swift */; };
 		E15A8F5B7E6A925B33ECA315 /* KeychainDeviceID.swift in Sources */ = {isa = PBXBuildFile; fileRef = 382370F0C983ABEC82E06430 /* KeychainDeviceID.swift */; };
 		E634311FF9DEAEA0E074302E /* ImagePickerPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3150B50687617E509C16EC1D /* ImagePickerPresenter.swift */; };
+		F0364CB28BFA07CC324DF280 /* Constants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0F583D197E23AF06962CE81A /* Constants.swift */; };
 		F7B32FEF1E1A176C2710D831 /* PendingImageState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 773DBA5F5449A8B4C8E7D1AE /* PendingImageState.swift */; };
 		F955600133754F7655E89EB6 /* AudioRingBufferTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 25530A43AA8DC90AF7ED2C57 /* AudioRingBufferTests.swift */; };
 		FD026502AE44AEC997D48C0B /* ContextMenuView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB1FAB05086E60FFC302C3E6 /* ContextMenuView.swift */; };
@@ -83,9 +85,12 @@
 		04067ECD7983ACC50844C82D /* QuipLiveActivityBundle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuipLiveActivityBundle.swift; sourceTree = "<group>"; };
 		07BAAAC4E0E8051B6FF2664E /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		0B827C2D030F43E7C9485615 /* SeamStitcherTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SeamStitcherTests.swift; sourceTree = "<group>"; };
+		0BD4C0C02F1EAFBEEDC5EA1D /* PhoneLayoutChooserTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PhoneLayoutChooserTests.swift; sourceTree = "<group>"; };
+		0F583D197E23AF06962CE81A /* Constants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Constants.swift; sourceTree = "<group>"; };
 		109D3594919D4EF54DE97C72 /* QuipLiveActivityWidget.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuipLiveActivityWidget.swift; sourceTree = "<group>"; };
 		18AE69F5AEDB7F658B8657E8 /* QuipiOS.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = QuipiOS.entitlements; sourceTree = "<group>"; };
 		18E21C7F1FD2E724E4790F5D /* QuipLiveActivity.appex */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = "wrapper.app-extension"; path = QuipLiveActivity.appex; sourceTree = BUILT_PRODUCTS_DIR; };
+		1B0C4B6E9EA1F79748808978 /* RecognizerRolloverTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecognizerRolloverTests.swift; sourceTree = "<group>"; };
 		1D6ED80C8277F668CC0B273C /* ImageRecompressor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageRecompressor.swift; sourceTree = "<group>"; };
 		25530A43AA8DC90AF7ED2C57 /* AudioRingBufferTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioRingBufferTests.swift; sourceTree = "<group>"; };
 		28C25E9D2C8F4C324CDAF8B9 /* WindowRectangle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WindowRectangle.swift; sourceTree = "<group>"; };
@@ -104,6 +109,7 @@
 		4A833238659B2E7E8D205F45 /* WhisperAudioSenderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WhisperAudioSenderTests.swift; sourceTree = "<group>"; };
 		4B7A2E5808A455F967117889 /* PCMChunkerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PCMChunkerTests.swift; sourceTree = "<group>"; };
 		4E556291C05B9A0CF7C50AA5 /* WhisperAudioSender.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WhisperAudioSender.swift; sourceTree = "<group>"; };
+		50991F62509F0EBB3C8037B9 /* CertPins.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = CertPins.json; sourceTree = "<group>"; };
 		591693AB60296E1978E9F2D1 /* TerminalContentOverlay.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalContentOverlay.swift; sourceTree = "<group>"; };
 		5DE5492ADBC22C9381D58D40 /* QuipLiveActivityAttributes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuipLiveActivityAttributes.swift; sourceTree = "<group>"; };
 		5DED5CFC890EBB97FEDDAAFC /* ImageUploadMessageTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageUploadMessageTests.swift; sourceTree = "<group>"; };
@@ -121,8 +127,6 @@
 		A8B6A494C62E7118541A81C1 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		AB1FAB05086E60FFC302C3E6 /* ContextMenuView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContextMenuView.swift; sourceTree = "<group>"; };
 		AD67F0481CA1F97EEB2F5D7C /* InlineTerminalContentBranchTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InlineTerminalContentBranchTests.swift; sourceTree = "<group>"; };
-		B5803A385303C46EA4D51BE3 /* RecognizerRolloverTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecognizerRolloverTests.swift; sourceTree = "<group>"; };
-		859196B75583406E935B86A7 /* PhoneLayoutChooserTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PhoneLayoutChooserTests.swift; sourceTree = "<group>"; };
 		ADA867C4EE46E8D6EEA5EC8D /* PushRegistrationService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PushRegistrationService.swift; sourceTree = "<group>"; };
 		B3398B602525378B861B9218 /* Signing.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Signing.xcconfig; sourceTree = "<group>"; };
 		B5760F08A42C6C6570E49A4B /* WebSocketClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebSocketClient.swift; sourceTree = "<group>"; };
@@ -219,9 +223,9 @@
 				F37E465512A160C3F0FE0310 /* ImageRecompressorTests.swift */,
 				AD67F0481CA1F97EEB2F5D7C /* InlineTerminalContentBranchTests.swift */,
 				D6D5159A24459D33F4AE547B /* LinkifiedTerminalContentTests.swift */,
+				0BD4C0C02F1EAFBEEDC5EA1D /* PhoneLayoutChooserTests.swift */,
 				FFE14A146132EC2FDBF484D2 /* PTTStressTests.swift */,
-				B5803A385303C46EA4D51BE3 /* RecognizerRolloverTests.swift */,
-				859196B75583406E935B86A7 /* PhoneLayoutChooserTests.swift */,
+				1B0C4B6E9EA1F79748808978 /* RecognizerRolloverTests.swift */,
 				BB799E5EBA5A72A97A8EDD06 /* RemoteSpeechSessionTests.swift */,
 				47C70308C62E57B9CBBEFF9E /* SpeechServicePathSelectionTests.swift */,
 				4A833238659B2E7E8D205F45 /* WhisperAudioSenderTests.swift */,
@@ -261,6 +265,7 @@
 		A09650EC2B05403F60FD86D4 /* Resources */ = {
 			isa = PBXGroup;
 			children = (
+				50991F62509F0EBB3C8037B9 /* CertPins.json */,
 				38403BB3D3EAD614680767A6 /* dictation-vocab.txt */,
 			);
 			path = Resources;
@@ -270,6 +275,7 @@
 			isa = PBXGroup;
 			children = (
 				30CED6C2881B9B0070767205 /* AudioRingBuffer.swift */,
+				0F583D197E23AF06962CE81A /* Constants.swift */,
 				FE4E6BADD636034CE8C5EC9A /* MessageProtocol.swift */,
 				3FC01677A64725213479F75E /* PCMChunker.swift */,
 				6FE3FC3415A512C214E8D8D9 /* PTTWindowTracker.swift */,
@@ -418,6 +424,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				A977CCC72BA863A04F17FB77 /* Assets.xcassets in Resources */,
+				B712CA6389A8643DAA92C4FE /* CertPins.json in Resources */,
 				46B88647F52CB2FD8C378212 /* dictation-vocab.txt in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -453,8 +460,8 @@
 				27B8C39B88FB6144FECCDC55 /* PCMChunkerTests.swift in Sources */,
 				D574C92B13CDC64E5C200CAB /* PTTStressTests.swift in Sources */,
 				689A5ACEE675BEBE7608C903 /* PTTWindowTrackerTests.swift in Sources */,
-				BAE1BE644A1C4697BEE9DB46 /* RecognizerRolloverTests.swift in Sources */,
-				3EA86BE677664FD4A49B813D /* PhoneLayoutChooserTests.swift in Sources */,
+				35848956152082FFE9094000 /* PhoneLayoutChooserTests.swift in Sources */,
+				192A0DA56B5881A451A18799 /* RecognizerRolloverTests.swift in Sources */,
 				034FCCCD9B6278E606AB7BBE /* RemoteSpeechSessionTests.swift in Sources */,
 				A795C27D5F398A26647E2B49 /* SeamStitcherTests.swift in Sources */,
 				1FED4AB0761613E80C3FAC9D /* SpeechServicePathSelectionTests.swift in Sources */,
@@ -471,6 +478,7 @@
 				4D0689B3D9653512F27A322D /* BonjourBrowser.swift in Sources */,
 				C10D61840E80EDAD704827A9 /* Color+Hex.swift in Sources */,
 				B74D4BBBD664959095BE58DE /* ConnectionStatusBar.swift in Sources */,
+				F0364CB28BFA07CC324DF280 /* Constants.swift in Sources */,
 				FD026502AE44AEC997D48C0B /* ContextMenuView.swift in Sources */,
 				2E3F0351CC5E90C934E0F0B2 /* HardwareButtonHandler.swift in Sources */,
 				E634311FF9DEAEA0E074302E /* ImagePickerPresenter.swift in Sources */,

--- a/QuipiOS/Services/PreferencesSyncService.swift
+++ b/QuipiOS/Services/PreferencesSyncService.swift
@@ -128,6 +128,8 @@ final class PreferencesSyncService {
         if let v = snapshot.pushQuietHoursEnd { d.set(v, forKey: "pushQuietHoursEnd") }
         if let v = snapshot.liveActivitiesEnabled { d.set(v, forKey: "liveActivitiesEnabled") }
         if let v = snapshot.ttsEnabled { d.set(v, forKey: "ttsEnabled") }
+        if let v = snapshot.quickSlotsJSON { d.set(v, forKey: "quickSlotsJSON") }
+        if let v = snapshot.customButtonsJSON { d.set(v, forKey: "customButtonsJSON") }
     }
 
     private func scheduleSync() {
@@ -181,7 +183,9 @@ final class PreferencesSyncService {
             pushQuietHoursStart: d.object(forKey: "pushQuietHoursStart") as? Int,
             pushQuietHoursEnd: d.object(forKey: "pushQuietHoursEnd") as? Int,
             liveActivitiesEnabled: d.object(forKey: "liveActivitiesEnabled") as? Bool,
-            ttsEnabled: d.object(forKey: "ttsEnabled") as? Bool
+            ttsEnabled: d.object(forKey: "ttsEnabled") as? Bool,
+            quickSlotsJSON: d.string(forKey: "quickSlotsJSON"),
+            customButtonsJSON: d.string(forKey: "customButtonsJSON")
         )
     }
 }

--- a/QuipiOS/project.yml
+++ b/QuipiOS/project.yml
@@ -45,7 +45,7 @@ targets:
       path: Info.plist
       properties:
         CFBundleDisplayName: Quip
-        CFBundleShortVersionString: 1.3.3
+        CFBundleShortVersionString: 1.3.4
         UILaunchScreen:
           UIColorName: ""
         NSSpeechRecognitionUsageDescription: Quip uses speech recognition to transcribe your voice commands for Claude Code.

--- a/QuipiOS/project.yml
+++ b/QuipiOS/project.yml
@@ -45,7 +45,7 @@ targets:
       path: Info.plist
       properties:
         CFBundleDisplayName: Quip
-        CFBundleShortVersionString: 1.3.4
+        CFBundleShortVersionString: 1.4.0
         UILaunchScreen:
           UIColorName: ""
         NSSpeechRecognitionUsageDescription: Quip uses speech recognition to transcribe your voice commands for Claude Code.

--- a/Shared/MessageProtocol.swift
+++ b/Shared/MessageProtocol.swift
@@ -514,6 +514,16 @@ struct PreferencesSnapshot: Codable, Sendable, Equatable {
     var pushQuietHoursEnd: Int?
     var liveActivitiesEnabled: Bool?
     var ttsEnabled: Bool?
+    /// JSON-encoded ordered slot list from the Apple-toolbar-style editor.
+    /// Supersedes `enabledQuickButtons` (kept for downgrade safety) — the
+    /// CSV is regenerated from the slot list's built-in entries on each
+    /// edit. Optional so older Macs without this field stay forward-
+    /// compatible.
+    var quickSlotsJSON: String?
+    /// JSON-encoded `[CustomButton]` definitions table referenced by the
+    /// slot list via UUID. Persisted separately so re-ordering doesn't
+    /// rewrite definitions.
+    var customButtonsJSON: String?
 
     init(
         enabledQuickButtons: String? = nil,
@@ -529,7 +539,9 @@ struct PreferencesSnapshot: Codable, Sendable, Equatable {
         pushQuietHoursStart: Int? = nil,
         pushQuietHoursEnd: Int? = nil,
         liveActivitiesEnabled: Bool? = nil,
-        ttsEnabled: Bool? = nil
+        ttsEnabled: Bool? = nil,
+        quickSlotsJSON: String? = nil,
+        customButtonsJSON: String? = nil
     ) {
         self.enabledQuickButtons = enabledQuickButtons
         self.tintContentBorder = tintContentBorder
@@ -545,6 +557,8 @@ struct PreferencesSnapshot: Codable, Sendable, Equatable {
         self.pushQuietHoursEnd = pushQuietHoursEnd
         self.liveActivitiesEnabled = liveActivitiesEnabled
         self.ttsEnabled = ttsEnabled
+        self.quickSlotsJSON = quickSlotsJSON
+        self.customButtonsJSON = customButtonsJSON
     }
 }
 

--- a/docs/superpowers/wishlist.md
+++ b/docs/superpowers/wishlist.md
@@ -899,3 +899,32 @@ Diagnosed autonomously via a Node.js fake-iOS-client (`/tmp/quip-content-probe.j
 5. `#10` + `#11` together (transport hardening) — verify pins first, ship as one PR.
 6. `#12` (sandbox) — last because it's the TCC-prompting one.
 7. Protocol items (`#17`, `#18`, `#19`, `#20`) — bump protocol version once, ship together.
+
+---
+
+### 43. Custom quick-buttons editor + reorderable slot row (✅ Done, eb-branch)
+
+**Status:** ✅ Done on `eb-branch` — commits `2ef5f6b` (UI tightening: same-letter slash grouping `/c…`, Notifications dropdown, keystroke-pill collision fix), `498a29d` (remove dedicated `/plan` quick button), `9283a69` (custom buttons + slot editor, v1.4.0). Installed on iPhone 17 Pro Max.
+
+**What shipped:**
+- Quick-button row goes from fixed 3-cluster layout (slash | answers | keystrokes) to a flat user-controlled ordered list, Apple-toolbar-style.
+- `Settings → Quick Buttons` editor: drag handle to reorder, swipe to delete, "+" toolbar menu adds Built-in / Custom / Spacer.
+- Custom-button form: label + optional SF Symbol + payload (Slash / Raw text / Keystroke) + auto-submit toggle.
+- Spacers (12pt fixed) for grouping between slots; user can stack multiples for wider gaps.
+- Same-letter slash grouping (`/c…` Menu pill) now spans built-ins + custom slash buttons.
+
+**Persistence:**
+- `quickSlotsJSON` (@AppStorage) — JSON-encoded `[QuickSlot]`, source of truth for the row.
+- `customButtonsJSON` (@AppStorage) — JSON-encoded `[CustomButton]` definitions referenced by UUID.
+- Legacy `enabledQuickButtons` CSV kept in sync with the slot list's built-ins for downgrade safety.
+- One-shot CSV→JSON migration on first launch in v1.4.0 — preserves existing order, auto-inserts spacers at category transitions so the upgraded row matches the old auto-cluster layout.
+- `PreferencesSnapshot` extended with `quickSlotsJSON` + `customButtonsJSON` so the slot list and definitions survive reinstall via the existing Mac WebSocket + iCloud KVS sync path.
+
+**Implementation notes:**
+- `QuickSlot` and `CustomPayload` use hand-rolled `Codable` because Swift's automatic synthesis fails for these enums under our build settings (`SWIFT_STRICT_CONCURRENCY=minimal`). Wire format is `kind` discriminator + per-case payload fields — adding a new case won't break decoding of older JSON.
+- Cascade-delete: removing a custom definition prunes any slots referencing its UUID in the same persist cycle.
+- The dedicated `/plan` built-in quick button was removed (`498a29d`) in favor of users defining their own custom button if they want one. `Shift+Tab` remains as a manual mode-cycle.
+
+**Acceptance test:** Settings → Quick Buttons → "+" → Custom Button → label "/btw", payload Slash `/btw `, auto-submit off → Save → row shows `/btw` pill → tap fires the slash text into Claude. Drag a Spacer between two pills → 12pt gap appears in the row. Reinstall the app via `devicectl` → editor reopens with the same slots + custom defs.
+
+**Related:** `QuipiOS/QuipApp.swift` (QuickSlot, CustomButton, QuickButtonsSheet, CustomButtonForm), `QuipiOS/Services/PreferencesSyncService.swift`, `Shared/MessageProtocol.swift:502+`.


### PR DESCRIPTION
## Summary

- iOS quick-button row replaced with reorderable Apple-toolbar-style editor (drag to reorder, swipe-delete, "+" menu adds Built-in / Custom / Spacer). Custom buttons support Slash / Raw text / Keystroke payloads + optional SF Symbol icon.
- Live preview inside the editor renders the actual pill row on the same dark surface as the keyboard; list rows now show pill-styled previews instead of generic SF Symbols.
- Settings reorganized into three labeled sections: **Appearance**, **Keyboard**, **Notifications**. Notifications behind a NavigationLink with one-line summary (On / Paused / Quiet 22:00–07:00); Quiet Hours collapsed to a single From/To row of compact Menu pickers.
- Same-letter slash buttons collapse into a "/c…" Menu pill (spans built-ins + custom slash buttons sharing a first letter).
- Slash payloads namespaced: \`/commit-push-pr\` → \`/commit-commands:commit-push-pr\`, \`/caveman\` → \`/caveman:caveman\` (the bare forms returned "Unknown command" against the actually installed plugins).
- Plan-mode dedicated quick button removed in favor of user-defined customs (Shift+Tab still cycles modes manually).
- Keystroke-cluster pill collision fixed (Image OR Text, not both stacked under a doubled background plate).
- Mac WS server retries listener bind every 5 s on failure (recovers from port-squatter scenarios that previously failed silently).
- Mac plan-mode handler assumes \`.normal\` when no indicator is detected AND Claude is running, instead of erroring out.
- Persistence: \`quickSlotsJSON\` and \`customButtonsJSON\` added to \`PreferencesSnapshot\` so the slot list + custom defs survive reinstall via Mac WebSocket + iCloud KVS — same sync path as the rest of the iOS prefs.
- iOS bumped to v1.4.0.
- QuipMac.xcodeproj regenerated to pick up \`AuthThrottle.swift\` + \`LogPaths.swift\` so Release builds compile.

## Test plan

- [ ] Force-quit + relaunch Quip on iPhone, confirm v1.4.0 build. One-shot CSV→JSON migration runs on first launch — existing row preserved, with auto-inserted spacers at category transitions.
- [ ] Settings → Keyboard → Quick Buttons → drag a row to reorder, swipe to delete, "+" → add Custom Button (label + payload + auto-submit). Preview row updates immediately.
- [ ] "+" menu shows already-placed built-ins disabled with "· added" suffix.
- [ ] Tap \`/commit-push-pr\` button — Claude Code receives \`/commit-commands:commit-push-pr\` and runs (no "Unknown command").
- [ ] Tap \`/caveman\` button — Claude switches to caveman mode.
- [ ] Reinstall app via \`devicectl\` — slot list + customs persist (iCloud KVS / Mac WS).
- [ ] Mac: kill WS listener while connected → phone reconnects within ~5 s (bind-retry).
- [ ] Mac: \`xcodebuild -scheme QuipMac -configuration Release\` from a clean checkout — succeeds with regenerated pbxproj.

🤖 Generated with [Claude Code](https://claude.com/claude-code)